### PR TITLE
[STEP 03] 박스오피스 앱 ― D\.O\., Jenna

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		E708A9BD2A0244D500E6CDAD /* NetworkServable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E708A9BC2A0244D500E6CDAD /* NetworkServable.swift */; };
 		E715375029F8B92200112BE6 /* BoxOfficeResultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E715374F29F8B92200112BE6 /* BoxOfficeResultDTO.swift */; };
 		E715375229F8B93100112BE6 /* MovieDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E715375129F8B93100112BE6 /* MovieDTO.swift */; };
+		E73658CD2A0DFA54006D3263 /* MovieCollectionViewListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73658CC2A0DFA54006D3263 /* MovieCollectionViewListCell.swift */; };
 		E7C1159929F61B5900497283 /* DailyBoxOfficeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C1159829F61B5900497283 /* DailyBoxOfficeDTO.swift */; };
 		E7C115C129F7606F00497283 /* BoxOfficeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C115C029F7606F00497283 /* BoxOfficeTests.swift */; };
 		E7C115C829F7667100497283 /* DailyBoxOfficeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C1159829F61B5900497283 /* DailyBoxOfficeDTO.swift */; };
@@ -63,6 +64,7 @@
 		E708A9BC2A0244D500E6CDAD /* NetworkServable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServable.swift; sourceTree = "<group>"; };
 		E715374F29F8B92200112BE6 /* BoxOfficeResultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeResultDTO.swift; sourceTree = "<group>"; };
 		E715375129F8B93100112BE6 /* MovieDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDTO.swift; sourceTree = "<group>"; };
+		E73658CC2A0DFA54006D3263 /* MovieCollectionViewListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCollectionViewListCell.swift; sourceTree = "<group>"; };
 		E7C1159829F61B5900497283 /* DailyBoxOfficeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyBoxOfficeDTO.swift; sourceTree = "<group>"; };
 		E7C115BE29F7606F00497283 /* BoxOfficeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoxOfficeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7C115C029F7606F00497283 /* BoxOfficeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeTests.swift; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 			children = (
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
 				63DF20F42970E1A0005DF7D1 /* Main.storyboard */,
+				E73658CC2A0DFA54006D3263 /* MovieCollectionViewListCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				E715375229F8B93100112BE6 /* MovieDTO.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
+				E73658CD2A0DFA54006D3263 /* MovieCollectionViewListCell.swift in Sources */,
 				E708A98C2A00F4E800E6CDAD /* NetworkError.swift in Sources */,
 				E7C1159929F61B5900497283 /* DailyBoxOfficeDTO.swift in Sources */,
 			);

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -551,7 +551,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -580,7 +580,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		3BBD8C3A2A024C1400B4DFDC /* MovieDetailDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBD8C392A024C1400B4DFDC /* MovieDetailDTO.swift */; };
 		63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */; };
 		63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */; };
-		63DF20F32970E1A0005DF7D1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* ViewController.swift */; };
+		63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */; };
 		63DF20F62970E1A0005DF7D1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F42970E1A0005DF7D1 /* Main.storyboard */; };
 		63DF20F82970E1A1005DF7D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F72970E1A1005DF7D1 /* Assets.xcassets */; };
 		63DF20FB2970E1A1005DF7D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */; };
@@ -52,7 +52,7 @@
 		63DF20EB2970E1A0005DF7D1 /* BoxOffice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoxOffice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		63DF20F22970E1A0005DF7D1 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeViewController.swift; sourceTree = "<group>"; };
 		63DF20F52970E1A0005DF7D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		63DF20F72970E1A1005DF7D1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		63DF20FA2970E1A1005DF7D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -246,7 +246,7 @@
 		E7C115CE29F7914400497283 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				63DF20F22970E1A0005DF7D1 /* ViewController.swift */,
+				63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -364,7 +364,7 @@
 			files = (
 				E708A9BD2A0244D500E6CDAD /* NetworkServable.swift in Sources */,
 				E708A9B92A01F8F800E6CDAD /* EndPointProtocol.swift in Sources */,
-				63DF20F32970E1A0005DF7D1 /* ViewController.swift in Sources */,
+				63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */,
 				3B3934502A03917C0064AB88 /* APIRepresentable.swift in Sources */,
 				3B39345E2A08C9C10064AB88 /* DailyBoxOfficeEndPoint.swift in Sources */,
 				3BBD8C3A2A024C1400B4DFDC /* MovieDetailDTO.swift in Sources */,

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -69,72 +69,11 @@ class BoxOfficeViewController: UIViewController {
     }
     
     private func configureMovieDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, MovieDTO> { cell, indexPath, item in
-            // config 생성
-            var config = cell.defaultContentConfiguration()
-            
-            // 랭크, 등락 Label생성
-            let rankLabel = UILabel()
-            rankLabel.textAlignment = .center
-            rankLabel.text = item.rank
-            rankLabel.font = .preferredFont(forTextStyle: .title1)
-            
-            
-            let rankStatusLabel = UILabel()
-            rankStatusLabel.textAlignment = .center
-            
-            let rankStatusImage = UIImageView()
-            
-            let rankStatusStackView = UIStackView(arrangedSubviews: [rankStatusImage, rankStatusLabel])
-            rankStatusStackView.axis = .horizontal
-            rankStatusStackView.alignment = .center
-            
-            let leftStackView = UIStackView(arrangedSubviews: [rankLabel, rankStatusStackView])
-            leftStackView.axis = .vertical
-            
-            // disclosureIndicator 추가
-            cell.accessories = [.disclosureIndicator()]
-            
-            cell.accessories.append(.customView(configuration: .init(customView: leftStackView, placement: .leading())))
-            
-            
-            // 랭크, 등락 text 추가
-            if item.rankOldAndNew == "NEW" {
-                rankStatusLabel.text = "신작"
-                rankStatusLabel.textColor = .systemRed
-            }
-            else {
-                if item.rankInten == "0" {
-                    rankStatusLabel.text = "-"
-                    rankStatusStackView.removeArrangedSubview(rankStatusImage)
-                }
-                else if item.rankInten.hasPrefix("-") {
-                    rankStatusLabel.text = item.rankInten.replacingOccurrences(of: "-", with: "")
-                    rankStatusImage.image = UIImage(systemName: "arrowtriangle.up.fill")
-                    rankStatusImage.tintColor = .systemRed
-                }
-                else {
-                    rankStatusLabel.text = item.rankInten
-                    rankStatusImage.image = UIImage(systemName: "arrowtriangle.down.fill")
-                    rankStatusImage.tintColor = .systemBlue
-                }
-            }
-
-            // 텍스트 입력
-            let todayCount = item.audienceCount.formatDecimal() ?? ""
-            let totalCount = item.audienceAcc.formatDecimal() ?? ""
-
-            config.text = item.name
-            config.secondaryText = "오늘 \(todayCount) / 총 \(totalCount)"
-            config.textProperties.font = .preferredFont(forTextStyle: .title3)
-            config.secondaryTextProperties.font = .preferredFont(forTextStyle: .subheadline)
-            
-            // 설정 완료
-            cell.contentConfiguration = config
-        }
+        let cellRegistration = UICollectionView.CellRegistration<MovieCollectionViewListCell, MovieDTO> { _, _, _ in }
         
         movieDataSource = UICollectionViewDiffableDataSource<Section, MovieDTO>(collectionView: movieCollectionView) { collectionView, indexPath, itemIdentifier in
             let cell = self.movieCollectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+            cell.update(movie: itemIdentifier)
             return cell
         }
         
@@ -207,21 +146,6 @@ class BoxOfficeViewController: UIViewController {
     }
     
 }
-
-fileprivate extension String {
-    
-    func formatDecimal() -> String? {
-        guard let number = Int(self) else {
-            return nil
-        }
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimal
-        
-        return numberFormatter.string(from: NSNumber(value: number))
-    }
-    
-}
-
 fileprivate extension Date {
     
     static var yesterday: Date {

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -28,8 +28,7 @@ class BoxOfficeViewController: UIViewController {
         let sample = DailyBoxOfficeEndPoint(date: "20220202")
         updateData(from: sample) {
             self.dailyBoxOffice = $0
-            let movies = self.dailyBoxOffice?.boxOfficeResult.dailyBoxOfficeList ?? []
-            self.applyDataSource(movies)
+            self.applyMovieDataSource()
         }
         
         setup()
@@ -54,9 +53,7 @@ class BoxOfficeViewController: UIViewController {
             return cell
         }
         
-        let defaultData = MovieDTO(rank: "", rankInten: "", rankOldAndNew: "", code: "", name: "", openDate: "", salesAmount: "", salesShare: "", salesInten: "", salesChange: "", salesAcc: "", audienceCount: "", audienceInten: "", audienceChange: "", audienceAcc: "", screenCount: "", showCount: "")
-        
-        applyDataSource([defaultData])
+        applyMovieDataSource()
     }
     
     private func configureUI() {
@@ -83,10 +80,11 @@ class BoxOfficeViewController: UIViewController {
         }
     }
     
-    private func applyDataSource(_ movies: [MovieDTO]) {
+    private func applyMovieDataSource() {
+        let movies = dailyBoxOffice?.boxOfficeResult.dailyBoxOfficeList
         var snapshot = NSDiffableDataSourceSnapshot<Section, MovieDTO>()
         snapshot.appendSections([.main])
-        snapshot.appendItems(movies)
+        snapshot.appendItems(movies ?? [])
         movieDataSource.apply(snapshot)
     }
     

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -81,7 +81,7 @@ class BoxOfficeViewController: UIViewController {
             else {
                 if item.rankInten == "0" {
                     rankStatusLabel.text = "-"
-                    
+                    rankStatusStackView.removeArrangedSubview(rankStatusImage)
                 }
                 else if item.rankInten.hasPrefix("-") {
                     rankStatusLabel.text = item.rankInten.replacingOccurrences(of: "-", with: "")

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -9,10 +9,14 @@ import UIKit
 
 class BoxOfficeViewController: UIViewController {
     
+    // MARK: - Private
     private let networkService = NetworkService()
     private var dailyBoxOffice: DailyBoxOfficeDTO?
     private var movieDetail: MovieDetailDTO?
     
+    private var movieCollectionView: UICollectionView! = nil
+    
+    // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -21,9 +25,28 @@ class BoxOfficeViewController: UIViewController {
             self.dailyBoxOffice = $0
         }
         
+        setup()
     }
     
-    func updateData<T: APIRepresentable, E: EndPointProtocol>(from api: E, completion: @escaping (T?) -> Void) where E.DTO == T {
+    // MARK: - Private function
+    private func setup() {
+        configureCollectionView()
+        configureUI()
+    }
+    
+    private func configureUI() {
+        view.addSubview(movieCollectionView)
+    }
+        
+    private func configureCollectionView() {
+        let config = UICollectionLayoutListConfiguration(appearance: .plain)
+        let layout = UICollectionViewCompositionalLayout.list(using: config)
+        let collectionView = UICollectionView(frame: view.frame, collectionViewLayout: layout)
+        collectionView.backgroundColor = .systemPink
+        movieCollectionView = collectionView
+    }
+    
+    private func updateData<T: APIRepresentable, E: EndPointProtocol>(from api: E, completion: @escaping (T?) -> Void) where E.DTO == T {
         networkService.fetchData(endPoint: api) { result in
             switch result {
             case .success(let data):

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -9,12 +9,17 @@ import UIKit
 
 class BoxOfficeViewController: UIViewController {
     
+    enum Section {
+        case main
+    }
+    
     // MARK: - Private
     private let networkService = NetworkService()
     private var dailyBoxOffice: DailyBoxOfficeDTO?
     private var movieDetail: MovieDetailDTO?
     
     private var movieCollectionView: UICollectionView! = nil
+    private var movieDataSource: UICollectionViewDiffableDataSource<Section, MovieDTO>! = nil
     
     // MARK: - Lifecycle
     override func viewDidLoad() {
@@ -30,15 +35,36 @@ class BoxOfficeViewController: UIViewController {
     
     // MARK: - Private function
     private func setup() {
-        configureCollectionView()
+        configureMovieCollectionView()
+        configureMovieDataSource()
         configureUI()
+    }
+    
+    private func configureMovieDataSource() {
+        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, MovieDTO> { cell, indexPath, item in
+            var content = cell.defaultContentConfiguration()
+            content.text = item.name
+            cell.contentConfiguration = content
+        }
+        
+        movieDataSource = UICollectionViewDiffableDataSource<Section, MovieDTO>(collectionView: movieCollectionView) { collectionView, indexPath, itemIdentifier in
+            let cell = self.movieCollectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+            return cell
+        }
+        
+        let dummyData = MovieDTO(rank: "", rankInten: "", rankOldAndNew: "", code: "", name: "", openDate: "", salesAmount: "", salesShare: "", salesInten: "", salesChange: "", salesAcc: "", audienceCount: "", audienceInten: "", audienceChange: "", audienceAcc: "", screenCount: "", showCount: "")
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Section, MovieDTO>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems([dummyData])
+        movieDataSource.apply(snapshot)
     }
     
     private func configureUI() {
         view.addSubview(movieCollectionView)
     }
         
-    private func configureCollectionView() {
+    private func configureMovieCollectionView() {
         let config = UICollectionLayoutListConfiguration(appearance: .plain)
         let layout = UICollectionViewCompositionalLayout.list(using: config)
         let collectionView = UICollectionView(frame: view.frame, collectionViewLayout: layout)

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -28,6 +28,8 @@ class BoxOfficeViewController: UIViewController {
         let sample = DailyBoxOfficeEndPoint(date: "20220202")
         updateData(from: sample) {
             self.dailyBoxOffice = $0
+            let movies = self.dailyBoxOffice?.boxOfficeResult.dailyBoxOfficeList ?? []
+            self.applyDataSource(movies)
         }
         
         setup()
@@ -52,12 +54,9 @@ class BoxOfficeViewController: UIViewController {
             return cell
         }
         
-        let dummyData = MovieDTO(rank: "", rankInten: "", rankOldAndNew: "", code: "", name: "", openDate: "", salesAmount: "", salesShare: "", salesInten: "", salesChange: "", salesAcc: "", audienceCount: "", audienceInten: "", audienceChange: "", audienceAcc: "", screenCount: "", showCount: "")
+        let defaultData = MovieDTO(rank: "", rankInten: "", rankOldAndNew: "", code: "", name: "", openDate: "", salesAmount: "", salesShare: "", salesInten: "", salesChange: "", salesAcc: "", audienceCount: "", audienceInten: "", audienceChange: "", audienceAcc: "", screenCount: "", showCount: "")
         
-        var snapshot = NSDiffableDataSourceSnapshot<Section, MovieDTO>()
-        snapshot.appendSections([.main])
-        snapshot.appendItems([dummyData])
-        movieDataSource.apply(snapshot)
+        applyDataSource([defaultData])
     }
     
     private func configureUI() {
@@ -82,6 +81,13 @@ class BoxOfficeViewController: UIViewController {
                 completion(nil)
             }
         }
+    }
+    
+    private func applyDataSource(_ movies: [MovieDTO]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, MovieDTO>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(movies)
+        movieDataSource.apply(snapshot)
     }
     
 }

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -26,7 +26,11 @@ class BoxOfficeViewController: UIViewController {
         super.viewDidLoad()
         
         setup()
-        let sample = DailyBoxOfficeEndPoint(date: "20230510")
+            
+        let yesterday = Date.yesterday
+        let yesterdayString = yesterday.string(format: .yyyyMMdd)
+        
+        let sample = DailyBoxOfficeEndPoint(date: yesterdayString)
         updateData(from: sample) {
             self.dailyBoxOffice = $0
             DispatchQueue.main.async {
@@ -37,14 +41,19 @@ class BoxOfficeViewController: UIViewController {
     
     // MARK: - Private function
     private func setup() {
+        updateNavigationTitle()
         configureMovieCollectionView()
         configureMovieDataSource()
         configureUI()
     }
     
-    // MARK: - DataSource
+    private func updateNavigationTitle() {
+        let yesterday = Date.yesterday
+        let yesterdayString = yesterday.string(format: .yyyy_MM_dd)
+        self.navigationController?.navigationBar.topItem?.title = yesterdayString
+    }   
+    
     private func configureMovieDataSource() {
-        // MARK: - CellRegistration
         let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, MovieDTO> { cell, indexPath, item in
             // config 생성
             var config = cell.defaultContentConfiguration()
@@ -108,7 +117,6 @@ class BoxOfficeViewController: UIViewController {
             cell.contentConfiguration = config
         }
         
-        // MARK: - 위에서 만든 Data 등록
         movieDataSource = UICollectionViewDiffableDataSource<Section, MovieDTO>(collectionView: movieCollectionView) { collectionView, indexPath, itemIdentifier in
             let cell = self.movieCollectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
             return cell
@@ -170,3 +178,28 @@ fileprivate extension String {
     }
     
 }
+
+fileprivate extension Date {
+    
+    static var yesterday: Date {
+        return Date(timeIntervalSinceNow: -24 * 60 * 60)
+    }
+    
+}
+
+fileprivate extension Date {
+    
+    enum DateFormat: String {
+        case yyyy_MM_dd = "yyyy-MM-dd"
+        case yyyyMMdd = "yyyyMMdd"
+    }
+    
+    func string(format: DateFormat) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format.rawValue
+        
+        return formatter.string(from: self)
+    }
+
+}
+

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -15,11 +15,24 @@ class BoxOfficeViewController: UIViewController {
     
     // MARK: - Private
     private let networkService = NetworkService()
-    private var dailyBoxOffice: DailyBoxOfficeDTO?
+    private var dailyBoxOffice: DailyBoxOfficeDTO? {
+        didSet {
+            DispatchQueue.main.async {
+                self.loadLabel.removeFromSuperview()
+            }
+        }
+    }
     private var movieDetail: MovieDetailDTO?
     
     private var movieCollectionView: UICollectionView! = nil
     private var movieDataSource: UICollectionViewDiffableDataSource<Section, MovieDTO>! = nil
+    
+    let loadLabel: UILabel = {
+        let label = UILabel()
+        label.text = "loading..."
+        label.textAlignment = .center
+        return label
+    }()
     
     // MARK: - Lifecycle
     override func viewDidLoad() {
@@ -144,6 +157,12 @@ class BoxOfficeViewController: UIViewController {
     
     private func configureUI() {
         view.addSubview(movieCollectionView)
+        
+        view.addSubview(loadLabel)
+        loadLabel.translatesAutoresizingMaskIntoConstraints = false
+        loadLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        loadLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        loadLabel.layer.zPosition = .greatestFiniteMagnitude
     }
     
     @objc

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -61,7 +61,12 @@ class BoxOfficeViewController: UIViewController {
     }
         
     private func configureMovieCollectionView() {
-        let config = UICollectionLayoutListConfiguration(appearance: .plain)
+        var config = UICollectionLayoutListConfiguration(appearance: .plain)
+        if #available(iOS 14.5, *) {
+            config.separatorConfiguration.bottomSeparatorVisibility = .hidden
+            config.separatorConfiguration.topSeparatorVisibility = .visible
+            config.separatorConfiguration.topSeparatorInsets = .init(top: 0, leading: -100, bottom: 0, trailing: -100)
+        }
         let layout = UICollectionViewCompositionalLayout.list(using: config)
         let collectionView = UICollectionView(frame: view.frame, collectionViewLayout: layout)
         collectionView.backgroundColor = .systemPink

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  BoxOfficeViewController.swift
 //  BoxOffice
 //
 //  Created by kjs on 13/01/23.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class BoxOfficeViewController: UIViewController {
     
     private let networkService = NetworkService()
     private var dailyBoxOffice: DailyBoxOfficeDTO?

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -78,9 +78,7 @@ final class BoxOfficeViewController: UIViewController {
             return cell
         }
         
-        DispatchQueue.main.async {
-            self.applyMovieDataSource()
-        }
+        applyMovieDataSource()
     }
     
     private func configureRefreshControl() {

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -43,9 +43,9 @@ class BoxOfficeViewController: UIViewController {
     
     private func configureMovieDataSource() {
         let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, MovieDTO> { cell, indexPath, item in
-            var content = cell.defaultContentConfiguration()
-            content.text = item.name
-            cell.contentConfiguration = content
+            var config = cell.defaultContentConfiguration()
+            config.text = item.name
+            cell.contentConfiguration = config
         }
         
         movieDataSource = UICollectionViewDiffableDataSource<Section, MovieDTO>(collectionView: movieCollectionView) { collectionView, indexPath, itemIdentifier in
@@ -69,7 +69,6 @@ class BoxOfficeViewController: UIViewController {
         }
         let layout = UICollectionViewCompositionalLayout.list(using: config)
         let collectionView = UICollectionView(frame: view.frame, collectionViewLayout: layout)
-        collectionView.backgroundColor = .systemPink
         movieCollectionView = collectionView
     }
     

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -7,25 +7,25 @@
 
 import UIKit
 
+fileprivate enum Section {
+    
+    case main
+    
+}
+
 final class BoxOfficeViewController: UIViewController {
     
-    enum Section {
-        case main
-    }
-    
     // MARK: - Private
+    
     private let networkService = NetworkService()   
     private var dailyBoxOffice: DailyBoxOfficeDTO? {
         didSet {
-            DispatchQueue.main.async {
-                self.loadLabel.removeFromSuperview()
-            }
+            removeLoadLabel()
         }
     }
     private var movieDetail: MovieDetailDTO?
-    
-    private var movieCollectionView: UICollectionView! = nil
-    private var movieDataSource: UICollectionViewDiffableDataSource<Section, MovieDTO>! = nil
+    private var movieCollectionView: UICollectionView!
+    private var movieDataSource: UICollectionViewDiffableDataSource<Section, MovieDTO>!
     
     private let loadLabel: UILabel = {
         let label = UILabel()
@@ -35,6 +35,7 @@ final class BoxOfficeViewController: UIViewController {
     }()
     
     // MARK: - Lifecycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
@@ -42,6 +43,13 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     // MARK: - Private function
+    
+    private func removeLoadLabel() {
+        DispatchQueue.main.async {
+            self.loadLabel.removeFromSuperview()
+        }
+    }
+    
     private func setup() {
         updateNavigationTitle()
         configureMovieCollectionView()
@@ -65,7 +73,7 @@ final class BoxOfficeViewController: UIViewController {
             config.separatorConfiguration.topSeparatorInsets = .init(top: 0, leading: -100, bottom: 0, trailing: -100)
         }
         let layout = UICollectionViewCompositionalLayout.list(using: config)
-        let collectionView = UICollectionView(frame: view.frame, collectionViewLayout: layout)
+        let collectionView = UICollectionView(frame: view.safeAreaLayoutGuide.layoutFrame, collectionViewLayout: layout)
         movieCollectionView = collectionView
     }
     
@@ -123,7 +131,7 @@ final class BoxOfficeViewController: UIViewController {
         }
     }
     
-    private func updateData<T: APIRepresentable, E: EndPointProtocol>(from api: E, completion: @escaping (T?) -> Void) where E.DTO == T {
+    private func updateData<E: EndPointProtocol>(from api: E, completion: @escaping (E.DTO?) -> Void)  {
         networkService.fetchData(endPoint: api) { result in
             switch result {
             case .success(let data):

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -7,14 +7,14 @@
 
 import UIKit
 
-class BoxOfficeViewController: UIViewController {
+final class BoxOfficeViewController: UIViewController {
     
     enum Section {
         case main
     }
     
     // MARK: - Private
-    private let networkService = NetworkService()
+    private let networkService = NetworkService()   
     private var dailyBoxOffice: DailyBoxOfficeDTO? {
         didSet {
             DispatchQueue.main.async {
@@ -27,7 +27,7 @@ class BoxOfficeViewController: UIViewController {
     private var movieCollectionView: UICollectionView! = nil
     private var movieDataSource: UICollectionViewDiffableDataSource<Section, MovieDTO>! = nil
     
-    let loadLabel: UILabel = {
+    private let loadLabel: UILabel = {
         let label = UILabel()
         label.text = "loading..."
         label.textAlignment = .center
@@ -94,6 +94,14 @@ class BoxOfficeViewController: UIViewController {
         movieCollectionView.refreshControl?.addTarget(self, action: #selector(refreshCollectionView), for: .valueChanged)
     }
     
+    @objc
+    private func refreshCollectionView() {
+        if movieCollectionView.refreshControl?.isRefreshing != false {
+            movieCollectionView.refreshControl?.endRefreshing()
+        }
+        updateYesterdayData()
+    }
+    
     private func configureUI() {
         view.addSubview(movieCollectionView)
         
@@ -102,14 +110,6 @@ class BoxOfficeViewController: UIViewController {
         loadLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         loadLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         loadLabel.layer.zPosition = .greatestFiniteMagnitude
-    }
-    
-    @objc
-    private func refreshCollectionView() {
-        if movieCollectionView.refreshControl?.isRefreshing != false {
-            movieCollectionView.refreshControl?.endRefreshing()
-        }
-        updateYesterdayData()
     }
     
     private func updateYesterdayData() {
@@ -146,19 +146,16 @@ class BoxOfficeViewController: UIViewController {
     }
     
 }
-fileprivate extension Date {
-    
-    static var yesterday: Date {
-        return Date(timeIntervalSinceNow: -24 * 60 * 60)
-    }
-    
-}
 
 fileprivate extension Date {
     
     enum DateFormat: String {
         case yyyy_MM_dd = "yyyy-MM-dd"
         case yyyyMMdd = "yyyyMMdd"
+    }
+    
+    static var yesterday: Date {
+        return Date(timeIntervalSinceNow: -24 * 60 * 60)
     }
     
     func string(format: DateFormat) -> String {

--- a/BoxOffice/Controllers/BoxOfficeViewController.swift
+++ b/BoxOffice/Controllers/BoxOfficeViewController.swift
@@ -48,6 +48,7 @@ final class BoxOfficeViewController: UIViewController {
         configureMovieDataSource()
         configureRefreshControl()
         configureUI()
+        animateLoadLabel()
     }
     
     private func updateNavigationTitle() {
@@ -109,7 +110,6 @@ final class BoxOfficeViewController: UIViewController {
         loadLabel.translatesAutoresizingMaskIntoConstraints = false
         loadLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         loadLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
-        loadLabel.layer.zPosition = .greatestFiniteMagnitude
     }
     
     private func updateYesterdayData() {
@@ -143,6 +143,15 @@ final class BoxOfficeViewController: UIViewController {
         snapshot.appendSections([.main])
         snapshot.appendItems(movies ?? [])
         movieDataSource.apply(snapshot)
+    }
+    
+    private func animateLoadLabel() {
+        let opacityKeyframe = CAKeyframeAnimation(keyPath: "opacity")
+        opacityKeyframe.values = [0.2, 0.5, 0.8, 0.5, 0.2]
+        opacityKeyframe.keyTimes = [0, 0.3, 0.5, 0.8, 1]
+        opacityKeyframe.duration = 0.8
+        opacityKeyframe.repeatCount = .infinity
+        loadLabel.layer.add(opacityKeyframe, forKey: "loading")
     }
     
 }

--- a/BoxOffice/Model/MovieDTO/DailyBoxOfficeDTO/MovieDTO.swift
+++ b/BoxOffice/Model/MovieDTO/DailyBoxOfficeDTO/MovieDTO.swift
@@ -5,7 +5,7 @@
 //  Created by 신동오 on 2023/04/26.
 //
 
-struct MovieDTO: Decodable {
+struct MovieDTO: Decodable, Hashable {
     
     let rank, rankInten, rankOldAndNew, code, name, openDate, salesAmount, salesShare, salesInten, salesChange, salesAcc, audienceCount, audienceInten, audienceChange, audienceAcc, screenCount, showCount: String
     

--- a/BoxOffice/View/Base.lproj/Main.storyboard
+++ b/BoxOffice/View/Base.lproj/Main.storyboard
@@ -1,24 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="NbT-Jf-HB9">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="tne-QT-ifu">
+        <!--Navigation Controller-->
+        <scene sceneID="McG-yp-0Mn">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <navigationController id="NbT-Jf-HB9" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="g0l-Du-F1J">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="zhW-EH-JRE" kind="relationship" relationship="rootViewController" id="YmF-V4-ddd"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7Vb-zP-9vV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-161" y="-67"/>
+        </scene>
+        <!--Box Office View Controller-->
+        <scene sceneID="cKa-op-wwV">
+            <objects>
+                <viewController id="zhW-EH-JRE" customClass="BoxOfficeViewController" customModule="BoxOffice" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RLm-ZW-yy9">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="XnU-DW-NgE"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Zz3-vP-CQZ"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="9bb-L8-Uc4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="611" y="-67"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/BoxOffice/View/MovieCollectionViewListCell.swift
+++ b/BoxOffice/View/MovieCollectionViewListCell.swift
@@ -7,24 +7,24 @@
 
 import UIKit
 
-class MovieCollectionViewListCell: UICollectionViewListCell {
+final class MovieCollectionViewListCell: UICollectionViewListCell {
     
-    let rankLabel: UILabel = {
+    private let rankLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
         label.font = .preferredFont(forTextStyle: .title1)
         return label
     }()
     
-    let rankStatusLabel: UILabel = {
+    private let rankStatusLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
         return label
     }()
     
-    let rankStatusImage = UIImageView()
+    private let rankStatusImage = UIImageView()
     
-    lazy var rankStatusStackView: UIStackView = {
+    private lazy var rankStatusStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .center
@@ -33,7 +33,7 @@ class MovieCollectionViewListCell: UICollectionViewListCell {
         return stackView
     }()
     
-    lazy var leftStackView: UIStackView = {
+    private lazy var leftStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.alignment = .center
@@ -54,7 +54,15 @@ class MovieCollectionViewListCell: UICollectionViewListCell {
         configureLayout()
     }
     
-    func configureLayout() {
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        rankLabel.text = nil
+        rankStatusLabel.text = nil
+        rankStatusImage.image = nil
+        rankStatusImage.isHidden = false
+    }
+    
+    private func configureLayout() {
         accessories = [.disclosureIndicator()]
         accessories.append(.customView(configuration: .init(customView: leftStackView, placement: .leading())))
     }
@@ -70,7 +78,7 @@ class MovieCollectionViewListCell: UICollectionViewListCell {
         else {
             if movie.rankInten == "0" {
                 rankStatusLabel.text = "-"
-                rankStatusStackView.removeArrangedSubview(rankStatusImage)
+                rankStatusImage.isHidden = true
             }
             else if movie.rankInten.hasPrefix("-") {
                 rankStatusLabel.text = movie.rankInten.replacingOccurrences(of: "-", with: "")
@@ -94,7 +102,6 @@ class MovieCollectionViewListCell: UICollectionViewListCell {
         config.textProperties.font = .preferredFont(forTextStyle: .title3)
         config.secondaryTextProperties.font = .preferredFont(forTextStyle: .subheadline)
         
-        // 설정 완료
         self.contentConfiguration = config
     }
     

--- a/BoxOffice/View/MovieCollectionViewListCell.swift
+++ b/BoxOffice/View/MovieCollectionViewListCell.swift
@@ -1,0 +1,115 @@
+//
+//  MovieCollectionViewListCell.swift
+//  BoxOffice
+//
+//  Created by 신동오 on 2023/05/12.
+//
+
+import UIKit
+
+class MovieCollectionViewListCell: UICollectionViewListCell {
+    
+    let rankLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .preferredFont(forTextStyle: .title1)
+        return label
+    }()
+    
+    let rankStatusLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        return label
+    }()
+    
+    let rankStatusImage = UIImageView()
+    
+    lazy var rankStatusStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.addArrangedSubview(rankStatusImage)
+        stackView.addArrangedSubview(rankStatusLabel)
+        return stackView
+    }()
+    
+    lazy var leftStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.addArrangedSubview(rankLabel)
+        stackView.addArrangedSubview(rankStatusStackView)
+        return stackView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        configureLayout()
+    }
+    
+    func configureLayout() {
+        accessories = [.disclosureIndicator()]
+        accessories.append(.customView(configuration: .init(customView: leftStackView, placement: .leading())))
+    }
+    
+    func update(movie: MovieDTO) {
+        rankLabel.text = movie.rank
+        rankStatusLabel.text = movie.rankInten
+        
+        if movie.rankOldAndNew == "NEW" {
+            rankStatusLabel.text = "신작"
+            rankStatusLabel.textColor = .systemRed
+        }
+        else {
+            if movie.rankInten == "0" {
+                rankStatusLabel.text = "-"
+                rankStatusStackView.removeArrangedSubview(rankStatusImage)
+            }
+            else if movie.rankInten.hasPrefix("-") {
+                rankStatusLabel.text = movie.rankInten.replacingOccurrences(of: "-", with: "")
+                rankStatusImage.image = UIImage(systemName: "arrowtriangle.up.fill")
+                rankStatusImage.tintColor = .systemRed
+            }
+            else {
+                rankStatusLabel.text = movie.rankInten
+                rankStatusImage.image = UIImage(systemName: "arrowtriangle.down.fill")
+                rankStatusImage.tintColor = .systemBlue
+            }
+        }
+        
+        var config = self.defaultContentConfiguration()
+        
+        let todayCount = movie.audienceCount.formatDecimal() ?? ""
+        let totalCount = movie.audienceAcc.formatDecimal() ?? ""
+
+        config.text = movie.name
+        config.secondaryText = "오늘 \(todayCount) / 총 \(totalCount)"
+        config.textProperties.font = .preferredFont(forTextStyle: .title3)
+        config.secondaryTextProperties.font = .preferredFont(forTextStyle: .subheadline)
+        
+        // 설정 완료
+        self.contentConfiguration = config
+    }
+    
+}
+
+fileprivate extension String {
+    
+    func formatDecimal() -> String? {
+        guard let number = Int(self) else {
+            return nil
+        }
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        return numberFormatter.string(from: NSNumber(value: number))
+    }
+    
+}


### PR DESCRIPTION
안녕하세요 Cory🐾 @corykim0829
`디오` & `제나` 입니다 !  

`STEP3`는 네트워크 모델을 뷰에 연결하기 위한 로직을 만드는 단계였어요!
저희는 MVC 패턴으로 작성했기에 뷰컨트롤러 구현이 이번 스텝의 주된 작업이었습니다.
`BoxOfficeViewController.swift`, `MovieCollectionViewListCell.swift` 파일 위주로 살펴 주시면 감사하겠습니다 🤗

이번 피드백도 잘 부탁드려요 🙇🏻‍♀️🙇🏻‍♂️!!

---

　
# 요구 사항 및 구현

### 요구 사항
- [ ] STEP 2-1)　Test Double
- [x] STEP 2에서 구현한 네트워킹 기능을 통해 실제 영화 목록을 API 서버에 요청하여 불러오기
- [x] 어제의 박스오피스를 볼 수 있는 화면을 구현하기
    - [x] 당겨서 새로고침 기능
    - [x] 화면 상단에는 날짜를 표기, 불러온 정보는 리스트 형태로 구현
    - [x] 처음 목록을 로드할 때, 빈 화면 대신 로드 중임을 알리는 장치 구현

### 구현
<table>
    <thead>
        <tr style="background:#FFFBE4">
            <th colspan="1" style="text-align:center">폴더링</th>
            <th colspan="1" style="text-align:center">설명</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td style="background:#F8F8F8;"><pre><code>
├── BoxOffice
│   ├── Model
│   │   └── MovieDTO
│   │       ├── DailyBoxOfficeDTO
│   │       │   ├── BoxOfficeResultDTO.swift
│   │       │   ├── DailyBoxOfficeDTO.swift
│   │       │   └── MovieDTO.swift
│   │       └── MovieDetailDTO
│   │           └── MovieDetailDTO.swift
│   └── View
│   │   ├── Base.lproj
│   │   │   ├── LaunchScreen.storyboard
│   │   │   └── Main.storyboard
│   │   └── MovieCollectionViewListCell.swift
│   ├── Controllers
│   │   └── BoxOfficeViewController.swift
│   ├── Network
│   │   ├── Common
│   │   │   ├── APIRepresentable.swift
│   │   │   ├── HTTPMethodType.swift
│   │   │   └── NetworkError.swift
│   │   ├── EndPoint
│   │   │   ├── Implementation
│   │   │   │   ├── DailyBoxOfficeEndPoint.swift
│   │   │   │   └── MovieDetailEndPoint.swift
│   │   │   └── Interface
│   │   │       └── EndPointProtocol.swift
│   │   └── Service
│   │       ├── Implementation
│   │       │   └── NetworkService.swift
│   │       └── Interface
│   │           └── NetworkServable.swift
│   ├── AppDelegate.swift
│   ├── SceneDelegate.swift
│   ├── Assets.xcassets
│   ├── Info.plist
├── BoxOffice.xcodeproj
│   ├── project.pbxproj
│   ├── project.xcworkspace
├── BoxOfficeTests
│   ├── BoxOfficeTests.swift
│   └── TestData
│       └── DailyBoxOfficeData.json
└── README.md
            </code></pre></td>
            <td valign="top">
                <h3>Model</h3>
                <li><code>DailyBoxOfficeDTO</code>: 일일박스오피스 정의한 DTO</li>
                <li>
                    <code>MovieDetailDTO</code>: 개별영화 데이터를 정의한 DTO</li>
                <h3>View</h3>
                <li><code>MovieCollectionViewListCell.swift</code>: <code>CollectionView</code> 커스텀 셀 정의</li>
                <li><code>LaunchScreen</code></li>
                <li><code>Main</code></li>
                <h3>Controllers</h3>
                <li><code>BoxOfficeViewController</code>: 네트워크 호출 및 컬렉션 뷰 출력</li>
                <h3>Network</h3>
                <li><code>API</code>:  네트워크 통신에 필요한 엔드포인트, <code>url</code>, <code>urlRequest</code> 생성 </li>
                <li><code>NetworkError</code>: 네트워크시 발생한 에러타입 정의, <code>LocalizedError</code> 채택</li>
                <li><code>HTTPMethodType</code>: <code>get</code>, <code>post</code>, <code>put</code>, <code>delete</code> 정의</li>
                <li><code>NetworkServable</code>: <code>dataTask</code> 메서드를 정의한 프로토콜 구현</li>
            </td>
        </tr>
    </tbody>
</table>

　
　 
# 고민 및 질문
### ✔️　`파일 분리` vs `fileprivate extension`
숫자의 포맷(1,000)과 날짜 포맷(2023-05-12)을 맞추기 위해서 각각 `String`,`Date`에 대하여 `Extension`으로 구현을 하였어요
- `타입의 메서드로 구현`하면 타입의 인스턴스가 포맷을 바꿔주는 메서드를 가지게 되고, 해당 객체의 역할과 책임에는 어울리지 않는다고 생각했어요
- 그래서 `String`, `Date`의 `Extension`으로 구현하였어요. 이 때 포맷을 바꿔주는 함수는 해당 파일 안에서만 필요하고 다른 파일에서는 필요하지 않아 `fileprivate` 키워드로 작성하였어요
> 🙋‍♂️**(질문)** 로직에서 필요한 부분을 `Extension` 으로 처리하는 부분이 많아지면 파일이 길어지고 가독성이 떨어질 것 같은데요! 이런 부분은 어떻게 처리해야 할 지 궁금합니다.!

### ✔️　`apply(_:)`의 호출
저희가 구현한 `applyMovieDataSource()`메서드는  `UICollectionViewDiffableDataSource`의 `apply(_:)`를 호출하는 함수예요.
처음 앱을 켰을 때, api로부터의 데이터 수신이 완료되었을 때 ― 이렇게 2군데에서 사용하기 위해 구현했는데, main 스레드에서 호출해야 한다는 경고가 떴어요. 컴파일러가 권하는 대로 `DispatchQueue.main.async { }`로 감싸주려다가, 바로 수정하기보단 UI에 관한 이벤트가 아닌데도 main 스레드가 강제되는 이유를 정확히 알아보고 적용하기로 했어요.
그 결과, [공식문서](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource/3375795-apply)를 통해 다음과 같은 내용을 확인할 수 있었어요!
```
You can safely call this method from a background queue, but you must do so consistently in your app. Always call this method exclusively from the main queue or from a background queue.
```

다시 보니, `applyMovieDataSource()`의 호출은 다음 2군데에서 이루어지고 있었어요. ㄱ
   1. `updateYesterdayData()`에서: background queue (컴플리션 클로저 내에서)
   2. `configureMovieDataSource()`에서: main queue

컴파일러의 경고는 '`apply(_:)`는 메인 스레드에서 호출해야 한다'는 뜻이 아니라, '`apply(_:)`는 일관된 스레드에서 호출해야 하는데, 아무래도 메인 스레드에서가 낫겠다'는 뜻이었던 거예요 😳
이번 기회에 공식문서의 중요성을 다시금 되새길 수 있었어요 :-D

### ✔️　`prepareForReuse()`
커스텀 셀을 구현하며 부모타입에 없는 서브뷰들을 새로 정의해 주었어요.
dataSource의 데이터 일부는 기본구현 요소에(`.text`, `.secondaryText` 등), 
또 일부는 새로 넣어준 요소에(`rankLabel`, `rankStatusImage` 등) 바인딩 되는데요, 
따라서 prepareForReuse() 메서드를 재정의 하며 super.prepareForReuse() 호출 후 '새로 넣어준 요소'들에 바인딩 된 값을 nil로 할당하는 로직을 추가했어요.
> 여기서 질문! 🙋🏻‍♀️
> **Q. 기본구현 요소(상속받은 속성)에 대해서는 초기화 해줄 필요가 없는가?**
> - 테이블뷰와 기본 콜렉션뷰를 학습하며 그렇다고 알고 있었지만, 이번엔 diffable data source 등 셀과 데이터에 대한 작동기전에 있어 달라진 바가 많아 확실히 알고 싶었어요
> - UICollectionViewListCell은 UICollectionViewCell를 상속하므로 같은 prepareForReuse() 메서드를 갖고 있지만, 이 메서드가 상위의 prepareForReuse()와 달리 하위타입에서 추가로 기본구현 된 (UIListContentConfiguration의) .text, .secondaryText 등의 값도 초기화 해주고 있는지 정확히 확인할 자료를 찾지 못했어요.
> - 참고할 만한 문서나 키워드가 있다면 조언 부탁드려요🥲


### ✔️　updateData 메서드 제네릭 없애기
저번 스텝 피드백에서 `updateData<T, E>(from:completion:)`의 제네릭타입 `T: APIRepresentable`에 대해 언급해 주셨는데요, 
말씀해 주신 이유가 맞다고 생각해 이번에 리팩토링을 해보려 했지만 제네릭 명시를 하지 않으면 타입추론이 제대로 이루어지지 않는 문제를 만났어요...
뭔가 아주 기초적인 부분을 놓치고 있는 듯한데 찾지 못했어요 🤯

> **SOS** ⚡️
어떻게 변형하면 보다 깔끔한 코드가 될 수 있을지 힌트를 더 주실 수 있을까요...!! 


　 
　 