### PR TITLE
박스오피스 앱 [STEP4] Sidi, Yuni 

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -222,8 +222,8 @@
 				63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */,
 				63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */,
 				99DE23742B9DA8BF001CDFBC /* Navigator.swift */,
-				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
 				BDCA3EAE2BA6D40500F16FF2 /* DepengencyManager.swift */,
+				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
 			);
 			path = Application;
 			sourceTree = "<group>";

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		63DF20F82970E1A1005DF7D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F72970E1A1005DF7D1 /* Assets.xcassets */; };
 		63DF20FB2970E1A1005DF7D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */; };
 		990300D22B7B4B47009569CA /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 990300D12B7B4B47009569CA /* .swiftlint.yml */; };
+		9984D1C22BA2BBBC00AA2F57 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9984D1C12BA2BBBC00AA2F57 /* UILabel+.swift */; };
+		9984D1C42BA2BBCC00AA2F57 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9984D1C32BA2BBCC00AA2F57 /* UIStackView+.swift */; };
 		99C28D382B82E01F004A43E3 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D372B82E01F004A43E3 /* Movie.swift */; };
 		99C28D3C2B82E340004A43E3 /* MovieDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D3B2B82E340004A43E3 /* MovieDetailResponseDTO.swift */; };
 		99C28D652B849A37004A43E3 /* movie_detail_sample.json in Resources */ = {isa = PBXBuildFile; fileRef = 99C28D642B849A37004A43E3 /* movie_detail_sample.json */; };
@@ -102,6 +104,8 @@
 		63DF20FA2970E1A1005DF7D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		63DF20FC2970E1A1005DF7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		990300D12B7B4B47009569CA /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		9984D1C12BA2BBBC00AA2F57 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		9984D1C32BA2BBCC00AA2F57 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		99C28D372B82E01F004A43E3 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
 		99C28D3B2B82E340004A43E3 /* MovieDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailResponseDTO.swift; sourceTree = "<group>"; };
 		99C28D642B849A37004A43E3 /* movie_detail_sample.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = movie_detail_sample.json; sourceTree = "<group>"; };
@@ -402,6 +406,8 @@
 				99C28D742B8754C3004A43E3 /* Date+.swift */,
 				BD1A03622B8FC0C500031C0A /* UIViewController+.swift */,
 				BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */,
+				9984D1C32BA2BBCC00AA2F57 /* UIStackView+.swift */,
+				9984D1C12BA2BBBC00AA2F57 /* UILabel+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -535,6 +541,7 @@
 			files = (
 				BDA93E6F2B8F08C5000A43C6 /* BoxOfficeAPI.swift in Sources */,
 				BDFD20252B83AB5600E84042 /* DataTransferService.swift in Sources */,
+				9984D1C22BA2BBBC00AA2F57 /* UILabel+.swift in Sources */,
 				BD1A03632B8FC0C500031C0A /* UIViewController+.swift in Sources */,
 				99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */,
 				99DE23782B9DCBD3001CDFBC /* MovieImageDTO.swift in Sources */,
@@ -548,6 +555,7 @@
 				99DE23652B9A40EF001CDFBC /* MovieDetailRepository.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* MoviesListViewController.swift in Sources */,
 				99DE237E2B9DD1FC001CDFBC /* MovieImageUseCase.swift in Sources */,
+				9984D1C42BA2BBCC00AA2F57 /* UIStackView+.swift in Sources */,
 				BDA93E782B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				99DE23802B9DD9F3001CDFBC /* DefaultMovieImageRepository.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -26,6 +26,13 @@
 		99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */; };
 		99DE23632B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */; };
 		99DE23652B9A40EF001CDFBC /* MovieDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23642B9A40EF001CDFBC /* MovieDetailRepository.swift */; };
+		99DE23732B9CC450001CDFBC /* MovieDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23722B9CC450001CDFBC /* MovieDetailViewModel.swift */; };
+		99DE23752B9DA8BF001CDFBC /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23742B9DA8BF001CDFBC /* Navigator.swift */; };
+		99DE23782B9DCBD3001CDFBC /* MovieImageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23772B9DCBD3001CDFBC /* MovieImageDTO.swift */; };
+		99DE237A2B9DCCFE001CDFBC /* MovieImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23792B9DCCFE001CDFBC /* MovieImage.swift */; };
+		99DE237C2B9DD1AD001CDFBC /* MovieImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE237B2B9DD1AD001CDFBC /* MovieImageRepository.swift */; };
+		99DE237E2B9DD1FC001CDFBC /* MovieImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE237D2B9DD1FC001CDFBC /* MovieImageUseCase.swift */; };
+		99DE23802B9DD9F3001CDFBC /* DefaultMovieImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE237F2B9DD9F3001CDFBC /* DefaultMovieImageRepository.swift */; };
 		BD1A03632B8FC0C500031C0A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1A03622B8FC0C500031C0A /* UIViewController+.swift */; };
 		BD56989B2B7CC7A500704CCA /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFE901E2B7CB3160091339F /* String+.swift */; };
 		BD5698A32B7D9BE800704CCA /* BoxOfficeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5698A22B7D9BE800704CCA /* BoxOfficeResponseDTO.swift */; };
@@ -107,6 +114,13 @@
 		99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailUseCase.swift; sourceTree = "<group>"; };
 		99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMovieDetailRepository.swift; sourceTree = "<group>"; };
 		99DE23642B9A40EF001CDFBC /* MovieDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailRepository.swift; sourceTree = "<group>"; };
+		99DE23722B9CC450001CDFBC /* MovieDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewModel.swift; sourceTree = "<group>"; };
+		99DE23742B9DA8BF001CDFBC /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		99DE23772B9DCBD3001CDFBC /* MovieImageDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImageDTO.swift; sourceTree = "<group>"; };
+		99DE23792B9DCCFE001CDFBC /* MovieImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImage.swift; sourceTree = "<group>"; };
+		99DE237B2B9DD1AD001CDFBC /* MovieImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImageRepository.swift; sourceTree = "<group>"; };
+		99DE237D2B9DD1FC001CDFBC /* MovieImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImageUseCase.swift; sourceTree = "<group>"; };
+		99DE237F2B9DD9F3001CDFBC /* DefaultMovieImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMovieImageRepository.swift; sourceTree = "<group>"; };
 		BD1A03622B8FC0C500031C0A /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		BD5698A22B7D9BE800704CCA /* BoxOfficeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeResponseDTO.swift; sourceTree = "<group>"; };
 		BDA93E6C2B8F089C000A43C6 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
@@ -186,6 +200,7 @@
 				BDFE8FE42B7C7F650091339F /* BoxOffice.swift */,
 				BDFE8FE82B7C81030091339F /* MovieBoxOffice.swift */,
 				99C28D372B82E01F004A43E3 /* Movie.swift */,
+				99DE23792B9DCCFE001CDFBC /* MovieImage.swift */,
 				BD56989C2B7CCF3D00704CCA /* Enum */,
 			);
 			path = Entity;
@@ -198,6 +213,7 @@
 				63DF20FC2970E1A1005DF7D1 /* Info.plist */,
 				63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */,
 				63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */,
+				99DE23742B9DA8BF001CDFBC /* Navigator.swift */,
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
 			);
 			path = Application;
@@ -232,6 +248,7 @@
 			isa = PBXGroup;
 			children = (
 				99C28D842B88A7F7004A43E3 /* MoviesListViewModel.swift */,
+				99DE23722B9CC450001CDFBC /* MovieDetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -259,6 +276,7 @@
 			children = (
 				BD5698A22B7D9BE800704CCA /* BoxOfficeResponseDTO.swift */,
 				99C28D3B2B82E340004A43E3 /* MovieDetailResponseDTO.swift */,
+				99DE23772B9DCBD3001CDFBC /* MovieImageDTO.swift */,
 			);
 			path = Dto;
 			sourceTree = "<group>";
@@ -286,6 +304,7 @@
 			children = (
 				BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */,
 				99DE23642B9A40EF001CDFBC /* MovieDetailRepository.swift */,
+				99DE237B2B9DD1AD001CDFBC /* MovieImageRepository.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -295,6 +314,7 @@
 			children = (
 				BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */,
 				99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */,
+				99DE237D2B9DD1FC001CDFBC /* MovieImageUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -304,6 +324,7 @@
 			children = (
 				BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */,
 				99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */,
+				99DE237F2B9DD9F3001CDFBC /* DefaultMovieImageRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -513,26 +534,33 @@
 				BDFD20252B83AB5600E84042 /* DataTransferService.swift in Sources */,
 				BD1A03632B8FC0C500031C0A /* UIViewController+.swift in Sources */,
 				99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */,
+				99DE23782B9DCBD3001CDFBC /* MovieImageDTO.swift in Sources */,
 				BD5698A32B7D9BE800704CCA /* BoxOfficeResponseDTO.swift in Sources */,
+				99DE23752B9DA8BF001CDFBC /* Navigator.swift in Sources */,
 				BDFD20302B85DE5800E84042 /* Responsible.swift in Sources */,
 				99C28D382B82E01F004A43E3 /* Movie.swift in Sources */,
 				99C28D812B88A79A004A43E3 /* MoviesListCell.swift in Sources */,
 				BDFD201D2B836C9900E84042 /* Requestable.swift in Sources */,
 				99DE23652B9A40EF001CDFBC /* MovieDetailRepository.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* MoviesListViewController.swift in Sources */,
+				99DE237E2B9DD1FC001CDFBC /* MovieImageUseCase.swift in Sources */,
 				BDA93E782B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
+				99DE23802B9DD9F3001CDFBC /* DefaultMovieImageRepository.swift in Sources */,
 				BDFE8FEB2B7C82530091339F /* RankOldAndNew.swift in Sources */,
+				99DE237C2B9DD1AD001CDFBC /* MovieImageRepository.swift in Sources */,
 				BDFE8FE92B7C81030091339F /* MovieBoxOffice.swift in Sources */,
 				BDFE901F2B7CB3160091339F /* String+.swift in Sources */,
 				BDFE8FE72B7C80120091339F /* BoxOfficeType.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
 				99C28D752B8754C3004A43E3 /* Date+.swift in Sources */,
 				99C28D672B84A193004A43E3 /* NetworkSessionManager.swift in Sources */,
+				99DE23732B9CC450001CDFBC /* MovieDetailViewModel.swift in Sources */,
 				99C28D852B88A7F7004A43E3 /* MoviesListViewModel.swift in Sources */,
 				99C28D8A2B88EACE004A43E3 /* Bundle+.swift in Sources */,
 				BDA93E752B8F0A9D000A43C6 /* BoxOfficeUseCase.swift in Sources */,
 				99C28D3C2B82E340004A43E3 /* MovieDetailResponseDTO.swift in Sources */,
+				99DE237A2B9DCCFE001CDFBC /* MovieImage.swift in Sources */,
 				BDA93E6D2B8F089C000A43C6 /* API.swift in Sources */,
 				99DE23632B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift in Sources */,
 				BDFD201B2B836A1300E84042 /* NetworkService.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		99C28D8A2B88EACE004A43E3 /* Bundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D892B88EACE004A43E3 /* Bundle+.swift */; };
 		99C28D8C2B8E656B004A43E3 /* MovieDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8B2B8E656B004A43E3 /* MovieDetailView.swift */; };
 		99C28D8E2B8EE855004A43E3 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8D2B8EE855004A43E3 /* Observable.swift */; };
+		99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */; };
+		99DE23632B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */; };
+		99DE23652B9A40EF001CDFBC /* MovieDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23642B9A40EF001CDFBC /* MovieDetailRepository.swift */; };
 		BD1A03632B8FC0C500031C0A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1A03622B8FC0C500031C0A /* UIViewController+.swift */; };
 		BD56989B2B7CC7A500704CCA /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFE901E2B7CB3160091339F /* String+.swift */; };
 		BD5698A32B7D9BE800704CCA /* BoxOfficeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5698A22B7D9BE800704CCA /* BoxOfficeResponseDTO.swift */; };
@@ -101,6 +104,9 @@
 		99C28D892B88EACE004A43E3 /* Bundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+.swift"; sourceTree = "<group>"; };
 		99C28D8B2B8E656B004A43E3 /* MovieDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailView.swift; sourceTree = "<group>"; };
 		99C28D8D2B8EE855004A43E3 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailUseCase.swift; sourceTree = "<group>"; };
+		99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMovieDetailRepository.swift; sourceTree = "<group>"; };
+		99DE23642B9A40EF001CDFBC /* MovieDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailRepository.swift; sourceTree = "<group>"; };
 		BD1A03622B8FC0C500031C0A /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		BD5698A22B7D9BE800704CCA /* BoxOfficeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeResponseDTO.swift; sourceTree = "<group>"; };
 		BDA93E6C2B8F089C000A43C6 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
@@ -279,6 +285,7 @@
 			isa = PBXGroup;
 			children = (
 				BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */,
+				99DE23642B9A40EF001CDFBC /* MovieDetailRepository.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -287,6 +294,7 @@
 			isa = PBXGroup;
 			children = (
 				BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */,
+				99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -295,6 +303,7 @@
 			isa = PBXGroup;
 			children = (
 				BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */,
+				99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -503,11 +512,13 @@
 				BDA93E6F2B8F08C5000A43C6 /* BoxOfficeAPI.swift in Sources */,
 				BDFD20252B83AB5600E84042 /* DataTransferService.swift in Sources */,
 				BD1A03632B8FC0C500031C0A /* UIViewController+.swift in Sources */,
+				99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */,
 				BD5698A32B7D9BE800704CCA /* BoxOfficeResponseDTO.swift in Sources */,
 				BDFD20302B85DE5800E84042 /* Responsible.swift in Sources */,
 				99C28D382B82E01F004A43E3 /* Movie.swift in Sources */,
 				99C28D812B88A79A004A43E3 /* MoviesListCell.swift in Sources */,
 				BDFD201D2B836C9900E84042 /* Requestable.swift in Sources */,
+				99DE23652B9A40EF001CDFBC /* MovieDetailRepository.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* MoviesListViewController.swift in Sources */,
 				BDA93E782B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
@@ -523,6 +534,7 @@
 				BDA93E752B8F0A9D000A43C6 /* BoxOfficeUseCase.swift in Sources */,
 				99C28D3C2B82E340004A43E3 /* MovieDetailResponseDTO.swift in Sources */,
 				BDA93E6D2B8F089C000A43C6 /* API.swift in Sources */,
+				99DE23632B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift in Sources */,
 				BDFD201B2B836A1300E84042 /* NetworkService.swift in Sources */,
 				99C28D8C2B8E656B004A43E3 /* MovieDetailView.swift in Sources */,
 				BDA93E722B8F0A4E000A43C6 /* BoxOfficeRepository.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		BDA93E722B8F0A4E000A43C6 /* BoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */; };
 		BDA93E752B8F0A9D000A43C6 /* BoxOfficeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */; };
 		BDA93E782B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */; };
+		BDE9C2D12BA05EC500C4D38D /* UICollectionViewListCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */; };
 		BDFD201B2B836A1300E84042 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201A2B836A1300E84042 /* NetworkService.swift */; };
 		BDFD201D2B836C9900E84042 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201C2B836C9900E84042 /* Requestable.swift */; };
 		BDFD20202B837BDA00E84042 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201A2B836A1300E84042 /* NetworkService.swift */; };
@@ -128,6 +129,7 @@
 		BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRepository.swift; sourceTree = "<group>"; };
 		BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeUseCase.swift; sourceTree = "<group>"; };
 		BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBoxOfficeRepository.swift; sourceTree = "<group>"; };
+		BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewListCell+.swift"; sourceTree = "<group>"; };
 		BDFD201A2B836A1300E84042 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		BDFD201C2B836C9900E84042 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		BDFD20242B83AB5600E84042 /* DataTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTransferService.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				BDFE901E2B7CB3160091339F /* String+.swift */,
 				99C28D742B8754C3004A43E3 /* Date+.swift */,
 				BD1A03622B8FC0C500031C0A /* UIViewController+.swift */,
+				BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -536,6 +539,7 @@
 				99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */,
 				99DE23782B9DCBD3001CDFBC /* MovieImageDTO.swift in Sources */,
 				BD5698A32B7D9BE800704CCA /* BoxOfficeResponseDTO.swift in Sources */,
+				BDE9C2D12BA05EC500C4D38D /* UICollectionViewListCell+.swift in Sources */,
 				99DE23752B9DA8BF001CDFBC /* Navigator.swift in Sources */,
 				BDFD20302B85DE5800E84042 /* Responsible.swift in Sources */,
 				99C28D382B82E01F004A43E3 /* Movie.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		BDA93E722B8F0A4E000A43C6 /* BoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */; };
 		BDA93E752B8F0A9D000A43C6 /* BoxOfficeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */; };
 		BDA93E782B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */; };
+		BDCA3EAF2BA6D40500F16FF2 /* DepengencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3EAE2BA6D40500F16FF2 /* DepengencyManager.swift */; };
 		BDE9C2D12BA05EC500C4D38D /* UICollectionViewListCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */; };
 		BDFD201B2B836A1300E84042 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201A2B836A1300E84042 /* NetworkService.swift */; };
 		BDFD201D2B836C9900E84042 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201C2B836C9900E84042 /* Requestable.swift */; };
@@ -133,6 +134,7 @@
 		BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRepository.swift; sourceTree = "<group>"; };
 		BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeUseCase.swift; sourceTree = "<group>"; };
 		BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBoxOfficeRepository.swift; sourceTree = "<group>"; };
+		BDCA3EAE2BA6D40500F16FF2 /* DepengencyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepengencyManager.swift; sourceTree = "<group>"; };
 		BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewListCell+.swift"; sourceTree = "<group>"; };
 		BDFD201A2B836A1300E84042 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		BDFD201C2B836C9900E84042 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */,
 				99DE23742B9DA8BF001CDFBC /* Navigator.swift */,
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
+				BDCA3EAE2BA6D40500F16FF2 /* DepengencyManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -570,6 +573,7 @@
 				99DE23732B9CC450001CDFBC /* MovieDetailViewModel.swift in Sources */,
 				99C28D852B88A7F7004A43E3 /* MoviesListViewModel.swift in Sources */,
 				99C28D8A2B88EACE004A43E3 /* Bundle+.swift in Sources */,
+				BDCA3EAF2BA6D40500F16FF2 /* DepengencyManager.swift in Sources */,
 				BDA93E752B8F0A9D000A43C6 /* BoxOfficeUseCase.swift in Sources */,
 				99C28D3C2B82E340004A43E3 /* MovieDetailResponseDTO.swift in Sources */,
 				99DE237A2B9DCCFE001CDFBC /* MovieImage.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		99C28D812B88A79A004A43E3 /* MoviesListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D802B88A79A004A43E3 /* MoviesListCell.swift */; };
 		99C28D852B88A7F7004A43E3 /* MoviesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D842B88A7F7004A43E3 /* MoviesListViewModel.swift */; };
 		99C28D8A2B88EACE004A43E3 /* Bundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D892B88EACE004A43E3 /* Bundle+.swift */; };
-		99C28D8C2B8E656B004A43E3 /* MovieDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8B2B8E656B004A43E3 /* MovieDetailView.swift */; };
+		99C28D8C2B8E656B004A43E3 /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8B2B8E656B004A43E3 /* MovieDetailViewController.swift */; };
 		99C28D8E2B8EE855004A43E3 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8D2B8EE855004A43E3 /* Observable.swift */; };
 		99DE23612B9A4093001CDFBC /* MovieDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */; };
 		99DE23632B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */; };
@@ -49,7 +49,7 @@
 		BD97C30E2B95D63000FBF06C /* BoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E712B8F0A4E000A43C6 /* BoxOfficeRepository.swift */; };
 		BD97C30F2B95D63800FBF06C /* BoxOfficeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */; };
 		BD97C3102B95D63D00FBF06C /* MoviesListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D802B88A79A004A43E3 /* MoviesListCell.swift */; };
-		BD97C3112B95D64000FBF06C /* MovieDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8B2B8E656B004A43E3 /* MovieDetailView.swift */; };
+		BD97C3112B95D64000FBF06C /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D8B2B8E656B004A43E3 /* MovieDetailViewController.swift */; };
 		BD97C3122B95D64200FBF06C /* MoviesListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* MoviesListViewController.swift */; };
 		BD97C3142B95D64800FBF06C /* MoviesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C28D842B88A7F7004A43E3 /* MoviesListViewModel.swift */; };
 		BDA93E6D2B8F089C000A43C6 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E6C2B8F089C000A43C6 /* API.swift */; };
@@ -114,7 +114,7 @@
 		99C28D802B88A79A004A43E3 /* MoviesListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesListCell.swift; sourceTree = "<group>"; };
 		99C28D842B88A7F7004A43E3 /* MoviesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesListViewModel.swift; sourceTree = "<group>"; };
 		99C28D892B88EACE004A43E3 /* Bundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+.swift"; sourceTree = "<group>"; };
-		99C28D8B2B8E656B004A43E3 /* MovieDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailView.swift; sourceTree = "<group>"; };
+		99C28D8B2B8E656B004A43E3 /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
 		99C28D8D2B8EE855004A43E3 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		99DE23602B9A4092001CDFBC /* MovieDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailUseCase.swift; sourceTree = "<group>"; };
 		99DE23622B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMovieDetailRepository.swift; sourceTree = "<group>"; };
@@ -263,7 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				63DF20F22970E1A0005DF7D1 /* MoviesListViewController.swift */,
-				99C28D8B2B8E656B004A43E3 /* MovieDetailView.swift */,
+				99C28D8B2B8E656B004A43E3 /* MovieDetailViewController.swift */,
 				99C28D7E2B88A736004A43E3 /* Cell */,
 			);
 			path = View;
@@ -576,7 +576,7 @@
 				BDA93E6D2B8F089C000A43C6 /* API.swift in Sources */,
 				99DE23632B9A40D6001CDFBC /* DefaultMovieDetailRepository.swift in Sources */,
 				BDFD201B2B836A1300E84042 /* NetworkService.swift in Sources */,
-				99C28D8C2B8E656B004A43E3 /* MovieDetailView.swift in Sources */,
+				99C28D8C2B8E656B004A43E3 /* MovieDetailViewController.swift in Sources */,
 				BDA93E722B8F0A4E000A43C6 /* BoxOfficeRepository.swift in Sources */,
 				BDFE8FE52B7C7F650091339F /* BoxOffice.swift in Sources */,
 				99C28D8E2B8EE855004A43E3 /* Observable.swift in Sources */,
@@ -600,7 +600,7 @@
 				BD97C30E2B95D63000FBF06C /* BoxOfficeRepository.swift in Sources */,
 				BD97C3102B95D63D00FBF06C /* MoviesListCell.swift in Sources */,
 				BDFE90142B7C978B0091339F /* RankOldAndNew.swift in Sources */,
-				BD97C3112B95D64000FBF06C /* MovieDetailView.swift in Sources */,
+				BD97C3112B95D64000FBF06C /* MovieDetailViewController.swift in Sources */,
 				BD97C3142B95D64800FBF06C /* MoviesListViewModel.swift in Sources */,
 				BDFD20282B84507600E84042 /* NetworkServiceTests.swift in Sources */,
 				BDFE90132B7C97890091339F /* MovieBoxOffice.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		BDA93E752B8F0A9D000A43C6 /* BoxOfficeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */; };
 		BDA93E782B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */; };
 		BDCA3EAF2BA6D40500F16FF2 /* DepengencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3EAE2BA6D40500F16FF2 /* DepengencyManager.swift */; };
+		BDCA3EB12BA6E1A600F16FF2 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3EB02BA6E1A600F16FF2 /* UIImage+.swift */; };
+		BDCA3EB32BA6E49200F16FF2 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3EB22BA6E49200F16FF2 /* CacheManager.swift */; };
 		BDE9C2D12BA05EC500C4D38D /* UICollectionViewListCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */; };
 		BDFD201B2B836A1300E84042 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201A2B836A1300E84042 /* NetworkService.swift */; };
 		BDFD201D2B836C9900E84042 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFD201C2B836C9900E84042 /* Requestable.swift */; };
@@ -135,6 +137,8 @@
 		BDA93E742B8F0A9D000A43C6 /* BoxOfficeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeUseCase.swift; sourceTree = "<group>"; };
 		BDA93E772B8F0AFE000A43C6 /* DefaultBoxOfficeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBoxOfficeRepository.swift; sourceTree = "<group>"; };
 		BDCA3EAE2BA6D40500F16FF2 /* DepengencyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepengencyManager.swift; sourceTree = "<group>"; };
+		BDCA3EB02BA6E1A600F16FF2 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		BDCA3EB22BA6E49200F16FF2 /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewListCell+.swift"; sourceTree = "<group>"; };
 		BDFD201A2B836A1300E84042 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		BDFD201C2B836C9900E84042 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
@@ -352,6 +356,7 @@
 			children = (
 				BDFE901D2B7CB2FE0091339F /* Extension */,
 				99C28D8D2B8EE855004A43E3 /* Observable.swift */,
+				BDCA3EB22BA6E49200F16FF2 /* CacheManager.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -411,6 +416,7 @@
 				BDE9C2D02BA05EC500C4D38D /* UICollectionViewListCell+.swift */,
 				9984D1C32BA2BBCC00AA2F57 /* UIStackView+.swift */,
 				9984D1C12BA2BBBC00AA2F57 /* UILabel+.swift */,
+				BDCA3EB02BA6E1A600F16FF2 /* UIImage+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -570,7 +576,9 @@
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
 				99C28D752B8754C3004A43E3 /* Date+.swift in Sources */,
 				99C28D672B84A193004A43E3 /* NetworkSessionManager.swift in Sources */,
+				BDCA3EB32BA6E49200F16FF2 /* CacheManager.swift in Sources */,
 				99DE23732B9CC450001CDFBC /* MovieDetailViewModel.swift in Sources */,
+				BDCA3EB12BA6E1A600F16FF2 /* UIImage+.swift in Sources */,
 				99C28D852B88A7F7004A43E3 /* MoviesListViewModel.swift in Sources */,
 				99C28D8A2B88EACE004A43E3 /* Bundle+.swift in Sources */,
 				BDCA3EAF2BA6D40500F16FF2 /* DepengencyManager.swift in Sources */,

--- a/BoxOffice/Application/DepengencyManager.swift
+++ b/BoxOffice/Application/DepengencyManager.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+class DepengencyManager {
+    let sessionMananger = DefaultNetworkSessionManager()
+    lazy var networkService = DefaultNetworkService(sessionManager: sessionMananger)
+    lazy var dataTransferService = DefaultDataTransferService(with: networkService)
+    
+    func makeMoviesListViewController(navigator: Navigator) -> MoviesListViewController {
+        let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
+        let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
+        let movieListViewModel = MoviesListViewModel(useCase: boxOfficeUseCase)
+        return MoviesListViewController(viewModel: movieListViewModel, navigator: navigator)
+    }
+    
+    func makeMovieDetailViewController(navigator: Navigator,  
+                                       movieCode: String,
+                                       movieName: String) -> MovieDetailViewController {
+        let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: dataTransferService)
+        let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
+        
+        let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
+        let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
+        
+        let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase, movieCode: movieCode, movieName: movieName)
+        return MovieDetailViewController(viewModel: movieDetailViewModel, navigator: navigator)
+    }
+}

--- a/BoxOffice/Application/DepengencyManager.swift
+++ b/BoxOffice/Application/DepengencyManager.swift
@@ -18,10 +18,8 @@ final class DepengencyManager {
                                        movieName: String) -> MovieDetailViewController {
         let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: dataTransferService)
         let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
-        
         let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
         let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
-        
         let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, 
                                                         imageUseCase: movieImageUseCase,
                                                         movieCode: movieCode,

--- a/BoxOffice/Application/DepengencyManager.swift
+++ b/BoxOffice/Application/DepengencyManager.swift
@@ -1,15 +1,16 @@
 import Foundation
 
-class DepengencyManager {
-    let sessionMananger = DefaultNetworkSessionManager()
-    lazy var networkService = DefaultNetworkService(sessionManager: sessionMananger)
-    lazy var dataTransferService = DefaultDataTransferService(with: networkService)
+final class DepengencyManager {
+    private let sessionMananger = DefaultNetworkSessionManager()
+    private lazy var networkService = DefaultNetworkService(sessionManager: sessionMananger)
+    private lazy var dataTransferService = DefaultDataTransferService(with: networkService)
     
     func makeMoviesListViewController(navigator: Navigator) -> MoviesListViewController {
         let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
         let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
         let movieListViewModel = MoviesListViewModel(useCase: boxOfficeUseCase)
-        return MoviesListViewController(viewModel: movieListViewModel, navigator: navigator)
+        return MoviesListViewController(viewModel: movieListViewModel, 
+                                        navigator: navigator)
     }
     
     func makeMovieDetailViewController(navigator: Navigator,  
@@ -21,7 +22,11 @@ class DepengencyManager {
         let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
         let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
         
-        let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase, movieCode: movieCode, movieName: movieName)
-        return MovieDetailViewController(viewModel: movieDetailViewModel, navigator: navigator)
+        let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, 
+                                                        imageUseCase: movieImageUseCase,
+                                                        movieCode: movieCode,
+                                                        movieName: movieName)
+        return MovieDetailViewController(viewModel: movieDetailViewModel, 
+                                         navigator: navigator)
     }
 }

--- a/BoxOffice/Application/Info.plist
+++ b/BoxOffice/Application/Info.plist
@@ -5,7 +5,7 @@
 	<key>API_KEY</key>
 	<string>200e4c621bdbe013b21688934a6ab29c</string>
 	<key>Kakao_API_KEY</key>
-	<string>426d6eab07e03ccf42add55365c8dcad</string>
+	<string>KakaoAK 426d6eab07e03ccf42add55365c8dcad</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/BoxOffice/Application/Info.plist
+++ b/BoxOffice/Application/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>API_KEY</key>
 	<string>200e4c621bdbe013b21688934a6ab29c</string>
+	<key>Kakao_API_KEY</key>
+	<string>426d6eab07e03ccf42add55365c8dcad</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/BoxOffice/Application/Navigator.swift
+++ b/BoxOffice/Application/Navigator.swift
@@ -8,7 +8,7 @@ protocol NavigatorProtocol {
 class Navigator: NavigatorProtocol {
     enum Destination {
         case movieList
-        case detailMovie(movieCode: String)
+        case detailMovie(movieCode: String, movieName: String)
     }
     
     func initializeViewController(destination: Destination) -> UIViewController {
@@ -24,26 +24,27 @@ class Navigator: NavigatorProtocol {
             let moviesListViewController = MoviesListViewController(viewModel: movieListViewModel, navigator: self)
             let navigationController = UINavigationController(rootViewController: moviesListViewController)
             return navigationController
-        case .detailMovie(let movieCode):
+        case .detailMovie(let movieCode, let movieName):
             let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: dataTransferService)
             let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
             
-            // 이미지.....떼잉 쯧
             let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
             let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
+            
             let movieDetailViewModel = DefaltMovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase)
-            let movieDetailView = MovieDetailView(movieCode: movieCode, viewModel: movieDetailViewModel)
+            let movieDetailView = MovieDetailView(movieCode: movieCode, movieName: movieName, viewModel: movieDetailViewModel)
             return movieDetailView
         }
     }
     
     func navigate(to destination: Destination, from viewController: UIViewController) {
         switch destination {
-        case .detailMovie(let movieCode):
+        case .detailMovie(let movieCode, let movieName):
             guard let detailViewController = initializeViewController(destination: destination) as? MovieDetailView else {
                 fatalError("MovieDetailView 에러")
             }
             detailViewController.movieCode = movieCode
+            detailViewController.movieName = movieName
             viewController.navigationController?.pushViewController(detailViewController, animated: true)
         default:
             let destinationVC = initializeViewController(destination: destination)

--- a/BoxOffice/Application/Navigator.swift
+++ b/BoxOffice/Application/Navigator.swift
@@ -20,7 +20,7 @@ class Navigator: NavigatorProtocol {
         case .movieList:
             let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
             let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
-            let movieListViewModel = DefaultMoviesListViewModel(useCase: boxOfficeUseCase)
+            let movieListViewModel = MoviesListViewModel(useCase: boxOfficeUseCase)
             let moviesListViewController = MoviesListViewController(viewModel: movieListViewModel, navigator: self)
             let navigationController = UINavigationController(rootViewController: moviesListViewController)
             return navigationController
@@ -31,8 +31,8 @@ class Navigator: NavigatorProtocol {
             let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
             let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
             
-            let movieDetailViewModel = DefaltMovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase)
-            let movieDetailView = MovieDetailView(movieCode: movieCode, movieName: movieName, viewModel: movieDetailViewModel)
+            let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase, movieCode: movieCode, movieName: movieName)
+            let movieDetailView = MovieDetailView(viewModel: movieDetailViewModel)
             return movieDetailView
         }
     }
@@ -43,8 +43,6 @@ class Navigator: NavigatorProtocol {
             guard let detailViewController = initializeViewController(destination: destination) as? MovieDetailView else {
                 fatalError("MovieDetailView 에러")
             }
-            detailViewController.movieCode = movieCode
-            detailViewController.movieName = movieName
             viewController.navigationController?.pushViewController(detailViewController, animated: true)
         default:
             let destinationVC = initializeViewController(destination: destination)

--- a/BoxOffice/Application/Navigator.swift
+++ b/BoxOffice/Application/Navigator.swift
@@ -1,8 +1,53 @@
-//
-//  Navigator.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/10/24.
-//
+import UIKit
 
-import Foundation
+protocol NavigatorProtocol {
+    func initializeViewController(destination: Navigator.Destination) -> UIViewController
+    func navigate(to destination: Navigator.Destination, from viewController: UIViewController)
+}
+
+class Navigator: NavigatorProtocol {
+    enum Destination {
+        case movieList
+        case detailMovie(movieCode: String)
+    }
+    
+    func initializeViewController(destination: Destination) -> UIViewController {
+        let sessionMananger = DefaultNetworkSessionManager()
+        let networkService = DefaultNetworkService(sessionManager: sessionMananger)
+        let dataTransferService = DefaultDataTransferService(with: networkService)
+        
+        switch destination {
+        case .movieList:
+            let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
+            let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
+            let movieListViewModel = DefaultMoviesListViewModel(useCase: boxOfficeUseCase)
+            let moviesListViewController = MoviesListViewController(viewModel: movieListViewModel, navigator: self)
+            let navigationController = UINavigationController(rootViewController: moviesListViewController)
+            return navigationController
+        case .detailMovie(let movieCode):
+            let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: dataTransferService)
+            let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
+            
+            // 이미지.....떼잉 쯧
+            let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
+            let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
+            let movieDetailViewModel = DefaltMovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase)
+            let movieDetailView = MovieDetailView(movieCode: movieCode, viewModel: movieDetailViewModel)
+            return movieDetailView
+        }
+    }
+    
+    func navigate(to destination: Destination, from viewController: UIViewController) {
+        switch destination {
+        case .detailMovie(let movieCode):
+            guard let detailViewController = initializeViewController(destination: destination) as? MovieDetailView else {
+                fatalError("MovieDetailView 에러")
+            }
+            detailViewController.movieCode = movieCode
+            viewController.navigationController?.pushViewController(detailViewController, animated: true)
+        default:
+            let destinationVC = initializeViewController(destination: destination)
+            viewController.navigationController?.setViewControllers([destinationVC], animated: true)
+        }
+    }
+}

--- a/BoxOffice/Application/Navigator.swift
+++ b/BoxOffice/Application/Navigator.swift
@@ -1,0 +1,8 @@
+//
+//  Navigator.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/10/24.
+//
+
+import Foundation

--- a/BoxOffice/Application/Navigator.swift
+++ b/BoxOffice/Application/Navigator.swift
@@ -32,15 +32,15 @@ class Navigator: NavigatorProtocol {
             let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
             
             let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase, movieCode: movieCode, movieName: movieName)
-            let movieDetailView = MovieDetailView(viewModel: movieDetailViewModel)
+            let movieDetailView = MovieDetailViewController(viewModel: movieDetailViewModel)
             return movieDetailView
         }
     }
     
     func navigate(to destination: Destination, from viewController: UIViewController) {
         switch destination {
-        case .detailMovie(let movieCode, let movieName):
-            guard let detailViewController = initializeViewController(destination: destination) as? MovieDetailView else {
+        case .detailMovie(_, _):
+            guard let detailViewController = initializeViewController(destination: destination) as? MovieDetailViewController else {
                 fatalError("MovieDetailView 에러")
             }
             viewController.navigationController?.pushViewController(detailViewController, animated: true)

--- a/BoxOffice/Application/Navigator.swift
+++ b/BoxOffice/Application/Navigator.swift
@@ -10,31 +10,18 @@ final class Navigator: NavigatorProtocol {
         case movieList
         case detailMovie(movieCode: String, movieName: String)
     }
-    
-    let sessionMananger = DefaultNetworkSessionManager()
-    lazy var networkService = DefaultNetworkService(sessionManager: sessionMananger)
-    lazy var dataTransferService = DefaultDataTransferService(with: networkService)
+    private let depengencyManager: DepengencyManager = DepengencyManager()
     
     func initializeViewController(destination: Destination) -> UIViewController {
         switch destination {
         case .movieList:
-            let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
-            let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
-            let movieListViewModel = MoviesListViewModel(useCase: boxOfficeUseCase)
-            let moviesListViewController = MoviesListViewController(viewModel: movieListViewModel, navigator: self)
-            let navigationController = UINavigationController(rootViewController: moviesListViewController)
+            let navigationController = UINavigationController(rootViewController: depengencyManager.makeMoviesListViewController(navigator: self))
             return navigationController
             
         case .detailMovie(let movieCode, let movieName):
-            let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: dataTransferService)
-            let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
-            
-            let movieImageRepository = DefaultMovieImageRepository(dataTransferService: dataTransferService)
-            let movieImageUseCase = DefaulMovieImageUseCase(movieImageRepository: movieImageRepository)
-            
-            let movieDetailViewModel = MovieDetailViewModel(detailUseCase: movieDetailUseCase, imageUseCase: movieImageUseCase, movieCode: movieCode, movieName: movieName)
-            let movieDetailView = MovieDetailViewController(viewModel: movieDetailViewModel, navigator: self)
-            return movieDetailView
+            return depengencyManager.makeMovieDetailViewController(navigator: self,
+                                                                   movieCode: movieCode,
+                                                                   movieName: movieName)
         }
     }
     

--- a/BoxOffice/Application/SceneDelegate.swift
+++ b/BoxOffice/Application/SceneDelegate.swift
@@ -1,9 +1,9 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
@@ -12,7 +12,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let dataTransferService = DefaultDataTransferService(with: networkService)
         let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
         let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
-        let movieListViewModel = DefaultMoviesListViewModel(useCase: boxOfficeUseCase)
+        
+        let defaultDataTransferService = DefaultDataTransferService(with: networkService)
+        let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: defaultDataTransferService)
+        let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
+        let movieListViewModel = DefaultMoviesListViewModel(useCase: boxOfficeUseCase, movieUseCase: movieDetailUseCase)
         
         let navigationController = UINavigationController(rootViewController: MoviesListViewController(viewModel: movieListViewModel))
         
@@ -20,14 +24,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) { }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) { }
-
+    
     func sceneWillResignActive(_ scene: UIScene) { }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) { }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) { }
 }

--- a/BoxOffice/Application/SceneDelegate.swift
+++ b/BoxOffice/Application/SceneDelegate.swift
@@ -7,21 +7,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        let sessionMananger = DefaultNetworkSessionManager()
-        let networkService = DefaultNetworkService(sessionManager: sessionMananger)
-        let dataTransferService = DefaultDataTransferService(with: networkService)
-        let boxOfficeRepository = DefaultBoxOfficeRepository(dataTransferService: dataTransferService)
-        let boxOfficeUseCase = DefaulBoxOfficeUseCase(boxOfficeRepository: boxOfficeRepository)
-        
-        let defaultDataTransferService = DefaultDataTransferService(with: networkService)
-        let movieDetailRepository = DefaultMovieDetailRepository(dataTransferService: defaultDataTransferService)
-        let movieDetailUseCase = DefaultMovieDetailUseCase(movieDetailRepository: movieDetailRepository)
-        let movieListViewModel = DefaultMoviesListViewModel(useCase: boxOfficeUseCase, movieUseCase: movieDetailUseCase)
-        
-        let navigationController = UINavigationController(rootViewController: MoviesListViewController(viewModel: movieListViewModel))
+        let navigator = Navigator()
+        let movieListViewController = navigator.initializeViewController(destination: .movieList)
         
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = navigationController
+        window?.rootViewController = movieListViewController
         window?.makeKeyAndVisible()
     }
     

--- a/BoxOffice/Data/Repository/DefaultMovieDetailRepository.swift
+++ b/BoxOffice/Data/Repository/DefaultMovieDetailRepository.swift
@@ -1,0 +1,8 @@
+//
+//  DefaultMovieDetailRepository.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/8/24.
+//
+
+import Foundation

--- a/BoxOffice/Data/Repository/DefaultMovieDetailRepository.swift
+++ b/BoxOffice/Data/Repository/DefaultMovieDetailRepository.swift
@@ -1,8 +1,23 @@
-//
-//  DefaultMovieDetailRepository.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/8/24.
-//
-
 import Foundation
+
+final class DefaultMovieDetailRepository {
+    private let dataTransferService: DefaultDataTransferService
+    
+    init(dataTransferService: DefaultDataTransferService) {
+        self.dataTransferService = dataTransferService
+    }
+}
+
+extension DefaultMovieDetailRepository: MovieDetailRepository {
+    func fetchBoxOfficeList(movieCode: String, completion: @escaping (Result<Movie, Error>) -> Void) -> URLSessionTask? {
+        return dataTransferService.request(with: API.movieAPI(with: movieCode)) { result in
+            switch result {
+            case .success(let movieDetailResponseDTO):
+                completion(.success(movieDetailResponseDTO.movieInfoResult.movieInfo.toModel()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+    

--- a/BoxOffice/Data/Repository/DefaultMovieImageRepository.swift
+++ b/BoxOffice/Data/Repository/DefaultMovieImageRepository.swift
@@ -1,0 +1,8 @@
+//
+//  DefaultMovieImageRepository.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/10/24.
+//
+
+import Foundation

--- a/BoxOffice/Data/Repository/DefaultMovieImageRepository.swift
+++ b/BoxOffice/Data/Repository/DefaultMovieImageRepository.swift
@@ -1,8 +1,22 @@
-//
-//  DefaultMovieImageRepository.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/10/24.
-//
-
 import Foundation
+
+final class DefaultMovieImageRepository {
+    private let dataTransferService: DataTransferService
+    
+    init(dataTransferService: DataTransferService) {
+        self.dataTransferService = dataTransferService
+    }
+}
+
+extension DefaultMovieImageRepository: MovieImageRepository {
+    func fetchMovieImage(for query: String, completion: @escaping (Result<MovieImage, Error>) -> Void) -> URLSessionTask? {
+        return dataTransferService.request(with: API.movieImage(query: query)) { result in
+            switch result {
+            case .success(let movieImageResponseDTO):
+                completion(.success(movieImageResponseDTO.toModel()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/BoxOffice/Domain/Entity/Movie.swift
+++ b/BoxOffice/Domain/Entity/Movie.swift
@@ -1,23 +1,16 @@
 import Foundation
 
 struct Movie {
-    private let movieCode: Int
-    private let movieName: String
-    private let englishMovieName: String
-    private let originalMovieName: String
-    private let productionYear: Int
-    private let duration: Int
-    private let openingDate: Date
-    private let productionStatus: ProductionStatus
-    private let runtimeType: RuntimeType
-    private let nations: [Nation]
-    private let genres: [Genre]
-    private let directors: [Director]
-    private let actors: [Performer]
-    private let showTypes: [ShowType]
-    private let companies: [Company]
-    private let audits: [Audit]
-    private let staffs: [Staff]
+    let movieCode: String
+    let movieName: String
+    let productionYear: Int
+    let duration: Int
+    let openingDate: Date
+    let nations: [Nation]
+    let genres: [Genre]
+    let directors: [Director]
+    let actors: [Performer]
+    let audits: [Audit]
 }
 
 struct Nation: Decodable {
@@ -139,22 +132,15 @@ enum RuntimeType: String {
 
 extension Movie {
     init(from movieDTO: MovieDetailResponseDTO.MovieInfoResultDTO.MovieDTO) {
-        self.movieCode = Int(movieDTO.movieCode) ?? 0
+        self.movieCode = movieDTO.movieCode
         self.movieName = movieDTO.movieName
-        self.englishMovieName = movieDTO.englishMovieName
-        self.originalMovieName = movieDTO.originalMovieName
         self.productionYear = Int(movieDTO.productionYear) ?? 0
         self.duration = Int(movieDTO.duration) ?? 0
-        self.openingDate = movieDTO.openingDate.toDate() ?? Date()
-        self.productionStatus = ProductionStatus(rawValue: movieDTO.productionStatus)
-        self.runtimeType = RuntimeType(rawValue: movieDTO.runtimeType)
+        self.openingDate = movieDTO.openingDate.toDate(with: DateFormatter.yyyyMMdd) ?? Date()
         self.nations = movieDTO.nations
         self.genres = movieDTO.genres
         self.directors = movieDTO.directors
         self.actors = movieDTO.actors
-        self.showTypes = movieDTO.showTypes
-        self.companies = movieDTO.companies
         self.audits = movieDTO.audits
-        self.staffs = movieDTO.staffs
     }
 }

--- a/BoxOffice/Domain/Entity/MovieImage.swift
+++ b/BoxOffice/Domain/Entity/MovieImage.swift
@@ -1,0 +1,8 @@
+//
+//  MovieImage.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/10/24.
+//
+
+import Foundation

--- a/BoxOffice/Domain/Entity/MovieImage.swift
+++ b/BoxOffice/Domain/Entity/MovieImage.swift
@@ -6,7 +6,7 @@ struct MovieImage {
 }
 
 struct MovieDocument {
-    let collection: Collection
+    let collection: String
     let datetime: String
     let displaySitename: String
     let docURL: String

--- a/BoxOffice/Domain/Entity/MovieImage.swift
+++ b/BoxOffice/Domain/Entity/MovieImage.swift
@@ -1,8 +1,40 @@
-//
-//  MovieImage.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/10/24.
-//
-
 import Foundation
+
+struct MovieImage {
+    let documents: [MovieDocument]
+    let meta: MovieImageMeta
+}
+
+struct MovieDocument {
+    let collection: Collection
+    let datetime: String
+    let displaySitename: String
+    let docURL: String
+    let height: Int
+    let imageURL: String
+    let thumbnailURL: String
+    let width: Int
+    
+    init(from documentDTO: MovieImageDTO.DocumentDTO) {
+        self.collection = documentDTO.collection
+        self.datetime = documentDTO.datetime
+        self.displaySitename = documentDTO.displaySitename
+        self.docURL = documentDTO.docURL
+        self.height = documentDTO.height
+        self.imageURL = documentDTO.imageURL
+        self.thumbnailURL = documentDTO.thumbnailURL
+        self.width = documentDTO.width
+    }
+}
+
+struct MovieImageMeta {
+    let isEnd: Bool
+    let pageableCount: Int
+    let totalCount: Int
+    
+    init(from metaDTO: MovieImageDTO.MetaDTO) {
+        self.isEnd = metaDTO.isEnd
+        self.pageableCount = metaDTO.pageableCount
+        self.totalCount = metaDTO.totalCount
+    }
+}

--- a/BoxOffice/Domain/Interface/MovieDetailRepository.swift
+++ b/BoxOffice/Domain/Interface/MovieDetailRepository.swift
@@ -1,8 +1,5 @@
-//
-//  MovieDetailRepository.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/8/24.
-//
-
 import Foundation
+
+protocol MovieDetailRepository {
+    func fetchBoxOfficeList(movieCode: String, completion: @escaping (Result<Movie, Error>) -> Void) -> URLSessionTask?
+}

--- a/BoxOffice/Domain/Interface/MovieDetailRepository.swift
+++ b/BoxOffice/Domain/Interface/MovieDetailRepository.swift
@@ -1,0 +1,8 @@
+//
+//  MovieDetailRepository.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/8/24.
+//
+
+import Foundation

--- a/BoxOffice/Domain/Interface/MovieImageRepository.swift
+++ b/BoxOffice/Domain/Interface/MovieImageRepository.swift
@@ -1,8 +1,5 @@
-//
-//  MovieImageRepository.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/10/24.
-//
-
 import Foundation
+
+protocol MovieImageRepository {
+    func fetchMovieImage(for query: String, completion: @escaping (Result<MovieImage, Error>) -> Void) -> URLSessionTask?
+}

--- a/BoxOffice/Domain/Interface/MovieImageRepository.swift
+++ b/BoxOffice/Domain/Interface/MovieImageRepository.swift
@@ -1,0 +1,8 @@
+//
+//  MovieImageRepository.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/10/24.
+//
+
+import Foundation

--- a/BoxOffice/Domain/UseCase/MovieDetailUseCase.swift
+++ b/BoxOffice/Domain/UseCase/MovieDetailUseCase.swift
@@ -1,8 +1,20 @@
-//
-//  MovieDetailUseCase.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/8/24.
-//
-
 import Foundation
+
+protocol MovieDetailUseCase {
+    @discardableResult
+    func fetch(movieCode: String, completion: @escaping (Result<Movie, Error>) -> Void) -> URLSessionTask?
+}
+
+final class DefaultMovieDetailUseCase: MovieDetailUseCase {
+    private let movieDetailRepository: MovieDetailRepository
+    
+    init(movieDetailRepository: MovieDetailRepository) {
+        self.movieDetailRepository = movieDetailRepository
+    }
+    
+    func fetch(movieCode: String, completion: @escaping (Result<Movie, Error>) -> Void) -> URLSessionTask? {
+        return movieDetailRepository.fetchBoxOfficeList(movieCode: movieCode) { result in
+            completion(result)
+        }
+    }
+}

--- a/BoxOffice/Domain/UseCase/MovieDetailUseCase.swift
+++ b/BoxOffice/Domain/UseCase/MovieDetailUseCase.swift
@@ -1,0 +1,8 @@
+//
+//  MovieDetailUseCase.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/8/24.
+//
+
+import Foundation

--- a/BoxOffice/Domain/UseCase/MovieImageUseCase.swift
+++ b/BoxOffice/Domain/UseCase/MovieImageUseCase.swift
@@ -1,8 +1,18 @@
-//
-//  movieImageUseCase.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/10/24.
-//
-
 import Foundation
+
+protocol MovieImageUseCase {
+    @discardableResult
+    func fetchMovieImage(movieName: String, completion: @escaping (Result<MovieImage, Error>) -> Void) -> URLSessionTask?
+}
+
+final class DefaulMovieImageUseCase: MovieImageUseCase {
+    private let movieImageRepository: MovieImageRepository
+    
+    init(movieImageRepository: MovieImageRepository) {
+        self.movieImageRepository = movieImageRepository
+    }
+    
+    func fetchMovieImage(movieName: String, completion: @escaping (Result<MovieImage, Error>) -> Void) -> URLSessionTask? {
+        return movieImageRepository.fetchMovieImage(for: movieName, completion: completion)
+    }
+}

--- a/BoxOffice/Domain/UseCase/MovieImageUseCase.swift
+++ b/BoxOffice/Domain/UseCase/MovieImageUseCase.swift
@@ -1,0 +1,8 @@
+//
+//  movieImageUseCase.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/10/24.
+//
+
+import Foundation

--- a/BoxOffice/Infra/Network/API/API.swift
+++ b/BoxOffice/Infra/Network/API/API.swift
@@ -16,4 +16,10 @@ struct API {
                         "key": Bundle.main.apiKey,
                         "movieCd": movieCode])
     }
+    
+    static func movieImage(query: String) -> APIConfig<MovieImageDTO> {
+        return .init(baseURL: BoxOfficeAPI.imageBaseUrl, path: BoxOfficeAPI.imagebasePath, queryParameters: [
+            "key": Bundle.main.kakaoApiKey,
+            "query": query])
+    }
 }

--- a/BoxOffice/Infra/Network/API/API.swift
+++ b/BoxOffice/Infra/Network/API/API.swift
@@ -18,8 +18,10 @@ struct API {
     }
     
     static func movieImage(query: String) -> APIConfig<MovieImageDTO> {
-        return .init(baseURL: BoxOfficeAPI.imageBaseUrl, path: BoxOfficeAPI.imagebasePath, queryParameters: [
-            "key": Bundle.main.kakaoApiKey,
-            "query": query])
+        return .init(baseURL: BoxOfficeAPI.imageBaseUrl,
+                     path: BoxOfficeAPI.movieImage.path,
+                     headerParameters: [
+                        "Authorization": Bundle.main.kakaoApiKey], queryParameters: [
+                            "query": "\(query) 영화 포스터"])
     }
 }

--- a/BoxOffice/Infra/Network/API/BoxOfficeAPI.swift
+++ b/BoxOffice/Infra/Network/API/BoxOfficeAPI.swift
@@ -1,13 +1,13 @@
 enum BoxOfficeAPI {
     case boxOffice
     case movie
-    case movieImage(query: String)
+    case movieImage
 }
 
 extension BoxOfficeAPI {
     static let baseUrl = "kobis.or.kr"
     static let basePath = "/kobisopenapi/webservice/rest"
-    static let imageBaseUrl = "https://example.com"
+    static let imageBaseUrl = "dapi.kakao.com"
     static let imagebasePath = "/v2/search/image"
     
     var path: String {
@@ -16,8 +16,8 @@ extension BoxOfficeAPI {
             return BoxOfficeAPI.basePath + "/boxoffice/searchDailyBoxOfficeList.json"
         case .movie:
             return BoxOfficeAPI.basePath + "/movie/searchMovieInfo.json"
-        case .movieImage(let query):
-            return BoxOfficeAPI.imagebasePath + "?query=\(query)"
+        case .movieImage:
+            return BoxOfficeAPI.imagebasePath
         }
     }
 }

--- a/BoxOffice/Infra/Network/API/BoxOfficeAPI.swift
+++ b/BoxOffice/Infra/Network/API/BoxOfficeAPI.swift
@@ -1,11 +1,14 @@
 enum BoxOfficeAPI {
     case boxOffice
     case movie
+    case movieImage(query: String)
 }
 
 extension BoxOfficeAPI {
     static let baseUrl = "kobis.or.kr"
     static let basePath = "/kobisopenapi/webservice/rest"
+    static let imageBaseUrl = "https://example.com"
+    static let imagebasePath = "/v2/search/image"
     
     var path: String {
         switch self {
@@ -13,6 +16,8 @@ extension BoxOfficeAPI {
             return BoxOfficeAPI.basePath + "/boxoffice/searchDailyBoxOfficeList.json"
         case .movie:
             return BoxOfficeAPI.basePath + "/movie/searchMovieInfo.json"
+        case .movieImage(let query):
+            return BoxOfficeAPI.imagebasePath + "?query=\(query)"
         }
     }
 }

--- a/BoxOffice/Infra/Network/Dto/MovieImageDTO.swift
+++ b/BoxOffice/Infra/Network/Dto/MovieImageDTO.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+// MARK: - MovieImage
+struct MovieImageDTO: Codable {
+    let documents: [Document]
+    let meta: Meta
+}
+
+// MARK: - Document
+struct Document: Codable {
+    let collection: Collection
+    /// 문서 작성 시간
+    let datetime: String
+    /// 출처
+    let displaySitename: String
+    /// 문서 url
+    let docURL: String
+    /// 이미지 세로길이
+    let height: Int
+    /// 이미지 url
+    let imageURL: String
+    /// 미리보기 이미지 url
+    let thumbnailURL: String
+    /// 이미지 가로길이
+    let width: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case collection, datetime
+        case displaySitename = "display_sitename"
+        case docURL = "doc_url"
+        case height
+        case imageURL = "image_url"
+        case thumbnailURL = "thumbnail_url"
+        case width
+    }
+}
+
+enum Collection: String, Codable {
+    case news = "news"
+}
+
+// MARK: - Meta
+struct Meta: Codable {
+    /// 현재 페이지가 마지막 페이지인지 여부
+    /// false 면 페이지 증가
+    let isEnd: Bool
+    /// 노출 가능 문서 수
+    let pageableCount: Int
+    /// 검색된 문서 수
+    let totalCount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case isEnd = "is_end"
+        case pageableCount = "pageable_count"
+        case totalCount = "total_count"
+    }
+}

--- a/BoxOffice/Infra/Network/Dto/MovieImageDTO.swift
+++ b/BoxOffice/Infra/Network/Dto/MovieImageDTO.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-struct MovieImageDTO: Codable {
+struct MovieImageDTO: Decodable {
     let documents: [DocumentDTO]
     let meta: MetaDTO
 }
 
 extension MovieImageDTO {
-    struct DocumentDTO: Codable {
-        let collection: Collection
+    struct DocumentDTO: Decodable {
+        let collection: String
         let datetime: String
         let displaySitename: String
         let docURL: String
@@ -28,13 +28,8 @@ extension MovieImageDTO {
     }
 }
 
-
-enum Collection: String, Codable {
-    case news = "news"
-}
-
 extension MovieImageDTO {
-    struct MetaDTO: Codable {
+    struct MetaDTO: Decodable {
         let isEnd: Bool
         let pageableCount: Int
         let totalCount: Int

--- a/BoxOffice/Infra/Network/Dto/MovieImageDTO.swift
+++ b/BoxOffice/Infra/Network/Dto/MovieImageDTO.swift
@@ -1,57 +1,60 @@
 import Foundation
 
-// MARK: - MovieImage
 struct MovieImageDTO: Codable {
-    let documents: [Document]
-    let meta: Meta
+    let documents: [DocumentDTO]
+    let meta: MetaDTO
 }
 
-// MARK: - Document
-struct Document: Codable {
-    let collection: Collection
-    /// 문서 작성 시간
-    let datetime: String
-    /// 출처
-    let displaySitename: String
-    /// 문서 url
-    let docURL: String
-    /// 이미지 세로길이
-    let height: Int
-    /// 이미지 url
-    let imageURL: String
-    /// 미리보기 이미지 url
-    let thumbnailURL: String
-    /// 이미지 가로길이
-    let width: Int
-    
-    enum CodingKeys: String, CodingKey {
-        case collection, datetime
-        case displaySitename = "display_sitename"
-        case docURL = "doc_url"
-        case height
-        case imageURL = "image_url"
-        case thumbnailURL = "thumbnail_url"
-        case width
+extension MovieImageDTO {
+    struct DocumentDTO: Codable {
+        let collection: Collection
+        let datetime: String
+        let displaySitename: String
+        let docURL: String
+        let height: Int
+        let imageURL: String
+        let thumbnailURL: String
+        let width: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case collection, datetime
+            case displaySitename = "display_sitename"
+            case docURL = "doc_url"
+            case height
+            case imageURL = "image_url"
+            case thumbnailURL = "thumbnail_url"
+            case width
+        }
     }
 }
+
 
 enum Collection: String, Codable {
     case news = "news"
 }
 
-// MARK: - Meta
-struct Meta: Codable {
-    /// 현재 페이지가 마지막 페이지인지 여부
-    /// false 면 페이지 증가
-    let isEnd: Bool
-    /// 노출 가능 문서 수
-    let pageableCount: Int
-    /// 검색된 문서 수
-    let totalCount: Int
-    
-    enum CodingKeys: String, CodingKey {
-        case isEnd = "is_end"
-        case pageableCount = "pageable_count"
-        case totalCount = "total_count"
+extension MovieImageDTO {
+    struct MetaDTO: Codable {
+        let isEnd: Bool
+        let pageableCount: Int
+        let totalCount: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case isEnd = "is_end"
+            case pageableCount = "pageable_count"
+            case totalCount = "total_count"
+        }
+    }
+}
+
+extension MovieImageDTO {
+    func toModel() -> MovieImage {
+        return .init(documents: self.documents.map { $0.toModel() }, meta: MovieImageMeta(from: self.meta))
+    }
+}
+
+extension MovieImageDTO.DocumentDTO {
+    func toModel() -> MovieDocument {
+        return .init(from: self)
     }
 }

--- a/BoxOffice/Infra/Util/CacheManager.swift
+++ b/BoxOffice/Infra/Util/CacheManager.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+class CacheManager {
+    static let shared = NSCache<NSString, UIImage>()
+    private init() {}
+}

--- a/BoxOffice/Infra/Util/Extension/Bundle+.swift
+++ b/BoxOffice/Infra/Util/Extension/Bundle+.swift
@@ -11,4 +11,15 @@ extension Bundle {
         }
         return key
     }
+    
+    var kakaoApiKey: String {
+        guard let file = self.path(forResource: "Info", ofType: "plist"),
+              let resoure = NSDictionary(contentsOfFile: file) else {
+            fatalError("Info.plist 파일을 찾을 수 없습니다.")
+        }
+        guard let key = resoure["Kakao_API_KEY"] as? String else {
+            fatalError("Kakao_API_KEY 키를 찾을 수 없습니다.")
+        }
+        return key
+    }
 }

--- a/BoxOffice/Infra/Util/Extension/Date+.swift
+++ b/BoxOffice/Infra/Util/Extension/Date+.swift
@@ -1,11 +1,13 @@
 import Foundation
 
 extension Date {
-    var yesterday: Date {
-        return Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? self
-    }
     func yesterdayString(with format: String) -> String {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? self
         return DateFormatter.formatter(with: format).string(from: yesterday)
+    }
+    
+    func openingDayString(with day: Date, with format: String) -> String {
+        return DateFormatter.formatter(with: format).string(from: day)
     }
 }
 

--- a/BoxOffice/Infra/Util/Extension/Date+.swift
+++ b/BoxOffice/Infra/Util/Extension/Date+.swift
@@ -6,7 +6,7 @@ extension Date {
         return DateFormatter.formatter(with: format).string(from: yesterday)
     }
     
-    func openingDayString(with day: Date, with format: String) -> String {
+    func openingDayString(day: Date, format: String) -> String {
         return DateFormatter.formatter(with: format).string(from: day)
     }
 }

--- a/BoxOffice/Infra/Util/Extension/String+.swift
+++ b/BoxOffice/Infra/Util/Extension/String+.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 extension String {
-    func toDate() -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
+    func toDate(with format: String) -> Date? {
+        let dateFormatter = DateFormatter.formatter(with: format)
         dateFormatter.timeZone = TimeZone(identifier: "KST")
         return dateFormatter.date(from: self)
     }

--- a/BoxOffice/Infra/Util/Extension/UICollectionViewListCell+.swift
+++ b/BoxOffice/Infra/Util/Extension/UICollectionViewListCell+.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension UICollectionViewListCell {
+    static var className: String {
+        return String(describing: self)
+    }
+}

--- a/BoxOffice/Infra/Util/Extension/UIImage+.swift
+++ b/BoxOffice/Infra/Util/Extension/UIImage+.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+extension UIImage {
+    static func load(with movieImage: MovieImage,
+                     completion: @escaping (UIImage?) -> Void) {
+        guard let imageURLString = movieImage.documents.first?.imageURL,
+              let imageURL = URL(string: imageURLString) else {
+            print("URL error")
+            return
+        }
+        
+        if let cachedImage = CacheManager.shared.object(forKey: NSString(string: imageURLString)) {
+            completion(cachedImage)
+            return
+        }
+        
+        DispatchQueue.global().async {
+            do {
+                let imageData = try Data(contentsOf: imageURL)
+                guard let image = UIImage(data: imageData) else { return }
+                CacheManager.shared.setObject(image, forKey: NSString(string: imageURLString))
+                DispatchQueue.main.async {
+                    completion(image)
+                }
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/BoxOffice/Infra/Util/Extension/UILabel+.swift
+++ b/BoxOffice/Infra/Util/Extension/UILabel+.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+extension UILabel {
+    func makeDetailLabel(text: String? = nil, textAlignment: NSTextAlignment, bold: Bool, numberOfLines: Int? = nil) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = bold ? .boldSystemFont(ofSize: 16) : .systemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = textAlignment
+        if let numberOfLines = numberOfLines {
+            label.numberOfLines = numberOfLines
+        }
+        return label
+    }
+    
+    func makeCellLabel(fontSize: Int, textColor: UIColor) -> UILabel {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: CGFloat(fontSize))
+        label.textColor = textColor
+        return label
+    }
+}

--- a/BoxOffice/Infra/Util/Extension/UIStackView+.swift
+++ b/BoxOffice/Infra/Util/Extension/UIStackView+.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIStackView {
+    func makeStackView(axis: NSLayoutConstraint.Axis, alignment: UIStackView.Alignment, spacing: Int) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = axis
+        stackView.alignment = alignment
+        stackView.distribution = .fill
+        stackView.spacing = CGFloat(spacing)
+        return stackView
+    }
+}

--- a/BoxOffice/Presentation/MoviesList/View/Cell/MoviesListCell.swift
+++ b/BoxOffice/Presentation/MoviesList/View/Cell/MoviesListCell.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 final class MoviesListCell: UICollectionViewListCell {
-
     private let rankStackView = UIStackView().makeStackView(axis: .vertical, alignment: .center, spacing: 4)
     private let titleAndAudienceStackView = UIStackView().makeStackView(axis: .vertical, alignment: .fill, spacing: 4)
     private let titleLabel = UILabel().makeCellLabel(fontSize: 15, textColor: .black)

--- a/BoxOffice/Presentation/MoviesList/View/Cell/MoviesListCell.swift
+++ b/BoxOffice/Presentation/MoviesList/View/Cell/MoviesListCell.swift
@@ -1,48 +1,13 @@
 import UIKit
 
 final class MoviesListCell: UICollectionViewListCell {
-    private let rankStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.distribution = .equalCentering
-        stackView.spacing = 4
-        return stackView
-    }()
-    private let titleAndAudienceStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.distribution = .equalCentering
-        stackView.spacing = 4
-        return stackView
-    }()
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    private let rankLabel: UILabel = {
-        let label = UILabel()
-        label.font = .boldSystemFont(ofSize: 25)
-        label.textColor = .black
-        return label
-    }()
-    private let changeLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 13)
-        label.textColor = .red
-        return label
-    }()
-    private let audienceLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .gray
-        return label
-    }()
+
+    private let rankStackView = UIStackView().makeStackView(axis: .vertical, alignment: .center, spacing: 4)
+    private let titleAndAudienceStackView = UIStackView().makeStackView(axis: .vertical, alignment: .fill, spacing: 4)
+    private let titleLabel = UILabel().makeCellLabel(fontSize: 15, textColor: .black)
+    private let rankLabel = UILabel().makeCellLabel(fontSize: 25, textColor: .black)
+    private let changeLabel = UILabel().makeCellLabel(fontSize: 13, textColor: .red)
+    private let audienceLabel = UILabel().makeCellLabel(fontSize: 14, textColor: .gray)
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
@@ -1,11 +1,231 @@
 import UIKit
 
 final class MovieDetailView: UIViewController {
-
-    private let movieName: String
     
-    init(movie: MovieBoxOffice) {
-        self.movieName = movie.movieName
+    private let movie: Movie
+    
+    // MARK: UIImageView
+    private let movieImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "photo.fill")
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    // MARK: UIScrollView
+    private let scrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    // MARK: UIStackView
+    private let stackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let directorStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let productionYearStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let openingDateStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let durationStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let ratingStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let nationsStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let genresStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private let actorsStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    // MARK: UILabel
+    private let directorTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "감독"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let directorsLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let productionYearTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "제작년도"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let productionYearLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let openingDateTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "개봉일"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let openingDateLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let durationTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "상영시간"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let durationLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let ratingTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "관람등급"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let ratingLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let nationsTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "제작국가"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let nationsLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let genresTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "장르"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let genresLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let actorsTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "배우"
+        label.font = .boldSystemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let actorsLabel: UILabel = {
+        let textView = UILabel()
+        textView.font = .systemFont(ofSize: 15)
+        textView.textColor = .black
+        textView.numberOfLines = 10
+        return textView
+    }()
+    
+    init(movie: Movie) {
+        self.movie = movie
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -17,9 +237,92 @@ final class MovieDetailView: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         setupNavigationBar()
+        setupViews()
+        configureLabels(with: movie)
     }
     
     private func setupNavigationBar() {
-        navigationItem.title = movieName
+        navigationItem.title = movie.movieName
+    }
+}
+
+// MARK: setupViews
+extension MovieDetailView {
+    private func setupViews() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        stackView.addArrangedSubview(movieImageView)
+        stackView.addArrangedSubview(directorStackView)
+        stackView.addArrangedSubview(productionYearStackView)
+        stackView.addArrangedSubview(openingDateStackView)
+        stackView.addArrangedSubview(durationStackView)
+        stackView.addArrangedSubview(ratingStackView)
+        stackView.addArrangedSubview(nationsStackView)
+        stackView.addArrangedSubview(genresStackView)
+        stackView.addArrangedSubview(actorsStackView)
+        
+        directorStackView.addArrangedSubview(directorTitleLabel)
+        directorStackView.addArrangedSubview(directorsLabel)
+        
+        productionYearStackView.addArrangedSubview(productionYearTitleLabel)
+        productionYearStackView.addArrangedSubview(productionYearLabel)
+        
+        openingDateStackView.addArrangedSubview(openingDateTitleLabel)
+        openingDateStackView.addArrangedSubview(openingDateLabel)
+        
+        durationStackView.addArrangedSubview(durationTitleLabel)
+        durationStackView.addArrangedSubview(durationLabel)
+        
+        ratingStackView.addArrangedSubview(ratingTitleLabel)
+        ratingStackView.addArrangedSubview(ratingLabel)
+        
+        nationsStackView.addArrangedSubview(nationsTitleLabel)
+        nationsStackView.addArrangedSubview(nationsLabel)
+        
+        genresStackView.addArrangedSubview(genresTitleLabel)
+        genresStackView.addArrangedSubview(genresLabel)
+        
+        actorsStackView.addArrangedSubview(actorsTitleLabel)
+        actorsStackView.addArrangedSubview(actorsLabel)
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 10),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 10),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -10),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -10),
+            stackView.widthAnchor.constraint(equalToConstant: 400),
+            
+            movieImageView.widthAnchor.constraint(equalToConstant: 420),
+            movieImageView.heightAnchor.constraint(equalToConstant: 300),
+            directorTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            productionYearTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            openingDateTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            durationTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            ratingTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            nationsTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            genresTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            actorsTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+        ])
+    }
+    
+    private func configureLabels(with movieDetail: Movie) {
+        //   movieImageView.image = UIImage(data: <#T##Data#>)
+        directorsLabel.text = "\(movieDetail.directors.map { $0.name }.joined(separator: ", "))"
+        productionYearLabel.text = "\(movieDetail.productionYear)"
+        openingDateLabel.text = Date().openingDayString(with: movieDetail.openingDate, with: DateFormatter.yyMMddDashed)
+        durationLabel.text = "\(movieDetail.duration)분"
+        ratingLabel.text = "\(movieDetail.audits.first?.rating ?? "-")"
+        nationsLabel.text = "\(movieDetail.nations.map { $0.name }.joined(separator: ", "))"
+        genresLabel.text = "\(movieDetail.genres.map { $0.name }.joined(separator: ", "))"
+        if movieDetail.actors.isEmpty {
+            actorsLabel.text = "-"
+        } else {
+            actorsLabel.text = "\(movieDetail.actors.map { "\($0.name)" }.joined(separator: ", "))"
+        }
     }
 }

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
@@ -2,286 +2,149 @@ import UIKit
 
 final class MovieDetailView: UIViewController {
     
-    private let movie: Movie
+    var movieCode: String
+    private var detailViewModel: MovieDetailViewModel
     
-    // MARK: UIImageView
-    private let movieImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "photo.fill")
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-    
-    // MARK: UIScrollView
-    private let scrollView = {
-        let scrollView = UIScrollView()
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        return scrollView
-    }()
-    
-    // MARK: UIStackView
-    private let stackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.alignment = .leading
-        stackView.distribution = .fill
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let directorStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let productionYearStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let openingDateStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let durationStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let ratingStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let nationsStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let genresStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    private let actorsStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        return stackView
-    }()
-    
-    // MARK: UILabel
-    private let directorTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "감독"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let directorsLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let productionYearTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "제작년도"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let productionYearLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let openingDateTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "개봉일"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let openingDateLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let durationTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "상영시간"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let durationLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let ratingTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "관람등급"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let ratingLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let nationsTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "제작국가"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let nationsLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let genresTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "장르"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let genresLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 15)
-        label.textColor = .black
-        return label
-    }()
-    
-    private let actorsTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "배우"
-        label.font = .boldSystemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = .center
-        return label
-    }()
-    
-    private let actorsLabel: UILabel = {
-        let textView = UILabel()
-        textView.font = .systemFont(ofSize: 15)
-        textView.textColor = .black
-        textView.numberOfLines = 10
-        return textView
-    }()
-    
-    init(movie: Movie) {
-        self.movie = movie
+    init(movieCode: String, viewModel: MovieDetailViewModel) {
+        self.movieCode = movieCode
+        self.detailViewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        detailViewModel.fetchMovieDetail(movieCode: movieCode)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: UIScrollView
+    private let scrollView =  UIScrollView()
+    
+    // MARK: UIImageView
+    private let movieImageView = UIImageView()
+    
+    // MARK: UIStackView
+    private lazy var totalStackView = makeStack(axis: .vertical, alignment: .leading)
+    private lazy var directorStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var productionYearStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var openingDateStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var durationStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var ratingStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var nationsStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var genresStackView = makeStack(axis: .horizontal, alignment: .center)
+    private lazy var actorsStackView = makeStack(axis: .horizontal, alignment: .center)
+    
+    // MARK: UILabel
+    private lazy var directorTitleLabel = makeLabel(text: "감독", textAlignment: .center, bold: true)
+    private lazy var directorsLabel = makeLabel(textAlignment: .left, bold: false)
+    private lazy var productionYearTitleLabel = makeLabel(text: "제작년도", textAlignment: .center, bold: true)
+    private lazy var productionYearLabel = makeLabel(textAlignment: .left, bold: false)
+    private lazy var openingDateTitleLabel = makeLabel(text: "개봉일", textAlignment: .center, bold: true)
+    private lazy var openingDateLabel = makeLabel(textAlignment: .center, bold: false)
+    private lazy var durationTitleLabel = makeLabel(text: "상영시간", textAlignment: .center, bold: true)
+    private lazy var durationLabel = makeLabel(textAlignment: .left, bold: false)
+    private lazy var ratingTitleLabel = makeLabel(text: "관람등급", textAlignment: .center, bold: true)
+    private lazy var ratingLabel = makeLabel( textAlignment: .left, bold: false)
+    private lazy var nationsTitleLabel = makeLabel(text: "제작국가", textAlignment: .center, bold: true)
+    private lazy var nationsLabel = makeLabel(textAlignment: .left, bold: false)
+    private lazy var genresTitleLabel = makeLabel(text: "장르", textAlignment: .center, bold: true)
+    private lazy var genresLabel = makeLabel(textAlignment: .left, bold: false)
+    private lazy var actorsTitleLabel = makeLabel(text: "배우", textAlignment: .center, bold: true)
+    private lazy var actorsLabel = makeLabel(textAlignment: .left, bold: false, numberOfLines: 10)
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        setupNavigationBar()
         setupViews()
-        configureLabels(with: movie)
-    }
-    
-    private func setupNavigationBar() {
-        navigationItem.title = movie.movieName
+        bind()
+        configureImageView()
     }
 }
 
-// MARK: setupViews
+// MARK: Binding
+extension MovieDetailView {
+    private func bind() {
+        detailViewModel.movieDetail.bind{ [weak self] movie in
+            guard let movie = movie else { return }
+            self?.configureLabels(with: movie)
+        }
+        detailViewModel.errorMessage.bind{ [weak self] errorMessage in
+            self?.makeAlert(message: errorMessage, confirmAction: nil)
+        }
+    }
+    
+    private func configureLabels(with movie: Movie) {
+        navigationItem.title = movie.movieName
+        directorsLabel.text = "\(movie.directors.map { $0.name }.joined(separator: ", "))"
+        productionYearLabel.text = "\(movie.productionYear)"
+        openingDateLabel.text = "\(Date().openingDayString(day: movie.openingDate, format: DateFormatter.yyMMddDashed))"
+        durationLabel.text = "\(movie.duration)분"
+        ratingLabel.text = "\(movie.audits.first?.rating ?? "-")"
+        nationsLabel.text = "\(movie.nations.map { $0.name }.joined(separator: ", "))"
+        genresLabel.text = "\(movie.genres.map { $0.name }.joined(separator: ", "))"
+        actorsLabel.text = "\(movie.actors.isEmpty ? "-" : movie.actors.map { $0.name }.joined(separator: ", "))"
+    }
+    
+    private func configureImageView() {
+        movieImageView.image = UIImage(systemName: "tree.fill")
+    }
+}
+
+// MARK: Custom
+extension MovieDetailView {
+    private func makeStack(axis: NSLayoutConstraint.Axis, alignment: UIStackView.Alignment) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = axis
+        stackView.alignment = alignment
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        return stackView
+    }
+    
+    private func makeLabel(text: String? = nil, textAlignment: NSTextAlignment, bold: Bool, numberOfLines: Int? = nil) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = bold ? .boldSystemFont(ofSize: 15) : .systemFont(ofSize: 15)
+        label.textColor = .black
+        label.textAlignment = textAlignment
+        if let numberOfLines = numberOfLines {
+            label.numberOfLines = numberOfLines
+        }
+        return label
+    }
+}
+
+// MARK: Layout
 extension MovieDetailView {
     private func setupViews() {
+        movieImageView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
-        scrollView.addSubview(stackView)
-        stackView.addArrangedSubview(movieImageView)
-        stackView.addArrangedSubview(directorStackView)
-        stackView.addArrangedSubview(productionYearStackView)
-        stackView.addArrangedSubview(openingDateStackView)
-        stackView.addArrangedSubview(durationStackView)
-        stackView.addArrangedSubview(ratingStackView)
-        stackView.addArrangedSubview(nationsStackView)
-        stackView.addArrangedSubview(genresStackView)
-        stackView.addArrangedSubview(actorsStackView)
+        scrollView.addSubview(totalStackView)
+        totalStackView.addArrangedSubview(movieImageView)
+        totalStackView.addArrangedSubview(directorStackView)
+        totalStackView.addArrangedSubview(productionYearStackView)
+        totalStackView.addArrangedSubview(openingDateStackView)
+        totalStackView.addArrangedSubview(durationStackView)
+        totalStackView.addArrangedSubview(ratingStackView)
+        totalStackView.addArrangedSubview(nationsStackView)
+        totalStackView.addArrangedSubview(genresStackView)
+        totalStackView.addArrangedSubview(actorsStackView)
         
         directorStackView.addArrangedSubview(directorTitleLabel)
         directorStackView.addArrangedSubview(directorsLabel)
-        
         productionYearStackView.addArrangedSubview(productionYearTitleLabel)
         productionYearStackView.addArrangedSubview(productionYearLabel)
-        
         openingDateStackView.addArrangedSubview(openingDateTitleLabel)
         openingDateStackView.addArrangedSubview(openingDateLabel)
-        
         durationStackView.addArrangedSubview(durationTitleLabel)
         durationStackView.addArrangedSubview(durationLabel)
-        
         ratingStackView.addArrangedSubview(ratingTitleLabel)
         ratingStackView.addArrangedSubview(ratingLabel)
-        
         nationsStackView.addArrangedSubview(nationsTitleLabel)
         nationsStackView.addArrangedSubview(nationsLabel)
-        
         genresStackView.addArrangedSubview(genresTitleLabel)
         genresStackView.addArrangedSubview(genresLabel)
-        
         actorsStackView.addArrangedSubview(actorsTitleLabel)
         actorsStackView.addArrangedSubview(actorsLabel)
         
@@ -291,14 +154,15 @@ extension MovieDetailView {
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             
-            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 10),
-            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 10),
-            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -10),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -10),
-            stackView.widthAnchor.constraint(equalToConstant: 400),
+            totalStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 10),
+            totalStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 10),
+            totalStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -10),
+            totalStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -10),
+            totalStackView.widthAnchor.constraint(equalToConstant: 410),
             
-            movieImageView.widthAnchor.constraint(equalToConstant: 420),
+            movieImageView.widthAnchor.constraint(equalToConstant: 410),
             movieImageView.heightAnchor.constraint(equalToConstant: 300),
+            
             directorTitleLabel.widthAnchor.constraint(equalToConstant: 60),
             productionYearTitleLabel.widthAnchor.constraint(equalToConstant: 60),
             openingDateTitleLabel.widthAnchor.constraint(equalToConstant: 60),
@@ -306,23 +170,7 @@ extension MovieDetailView {
             ratingTitleLabel.widthAnchor.constraint(equalToConstant: 60),
             nationsTitleLabel.widthAnchor.constraint(equalToConstant: 60),
             genresTitleLabel.widthAnchor.constraint(equalToConstant: 60),
-            actorsTitleLabel.widthAnchor.constraint(equalToConstant: 60),
+            actorsTitleLabel.widthAnchor.constraint(equalToConstant: 60)
         ])
-    }
-    
-    private func configureLabels(with movieDetail: Movie) {
-        //   movieImageView.image = UIImage(data: <#T##Data#>)
-        directorsLabel.text = "\(movieDetail.directors.map { $0.name }.joined(separator: ", "))"
-        productionYearLabel.text = "\(movieDetail.productionYear)"
-        openingDateLabel.text = Date().openingDayString(with: movieDetail.openingDate, with: DateFormatter.yyMMddDashed)
-        durationLabel.text = "\(movieDetail.duration)분"
-        ratingLabel.text = "\(movieDetail.audits.first?.rating ?? "-")"
-        nationsLabel.text = "\(movieDetail.nations.map { $0.name }.joined(separator: ", "))"
-        genresLabel.text = "\(movieDetail.genres.map { $0.name }.joined(separator: ", "))"
-        if movieDetail.actors.isEmpty {
-            actorsLabel.text = "-"
-        } else {
-            actorsLabel.text = "\(movieDetail.actors.map { "\($0.name)" }.joined(separator: ", "))"
-        }
     }
 }

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
@@ -1,18 +1,17 @@
 import UIKit
 
 final class MovieDetailView: UIViewController {
+    private var viewModel: MovieDetailViewModel
+    private var callMovieDetailEvent: Observable<Void> = Observable(())
+    private var callMovieImageEvent: Observable<Void> = Observable(())
     
-    var movieCode: String
-    var movieName: String
-    private var detailViewModel: MovieDetailViewModel
+    private lazy var input = MovieDetailViewModel.Input(callMovieDetailEvent: callMovieDetailEvent,
+                                                        callMovieImageEvent: callMovieImageEvent)
+    private lazy var output = viewModel.transform(input: input)
     
-    init(movieCode: String, movieName: String, viewModel: MovieDetailViewModel) {
-        self.movieCode = movieCode
-        self.movieName = movieName
-        self.detailViewModel = viewModel
+    init(viewModel: MovieDetailViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        detailViewModel.fetchMovieDetail(movieCode: movieCode)
-        detailViewModel.fetchMovieImage(movieName: movieName)
     }
     
     required init?(coder: NSCoder) {
@@ -69,20 +68,26 @@ final class MovieDetailView: UIViewController {
         addSubviewsAndSetupLayout()
         setupLayoutViews()
         bind()
+        callMovieData()
     }
 }
 
 // MARK: Binding
 extension MovieDetailView {
+    private func callMovieData() {
+        input.callMovieDetailEvent.value = ()
+        input.callMovieImageEvent.value = ()
+    }
+    
     private func bind() {
-        detailViewModel.movieDetail.bind{ [weak self] movie in
+        output.movieDetail.bind{ [weak self] movie in
             guard let movie = movie else { return }
             self?.configureLabels(with: movie)
         }
-        detailViewModel.errorMessage.bind{ [weak self] errorMessage in
+        output.errorMessage.bind{ [weak self] errorMessage in
             self?.makeAlert(message: errorMessage, confirmAction: nil)
         }
-        detailViewModel.movieImage.bind { [weak self] movieImage in
+        output.movieImage.bind { [weak self] movieImage in
             guard let movieImage = movieImage else { return }
             self?.configureImageView(with: movieImage)
         }

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailView.swift
@@ -34,33 +34,33 @@ final class MovieDetailView: UIViewController {
     private let movieImageView = UIImageView()
     
     // MARK: UIStackView
-    private lazy var totalStackView = makeStack(axis: .vertical, alignment: .leading)
-    private lazy var directorStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var productionYearStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var openingDateStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var durationStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var ratingStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var nationsStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var genresStackView = makeStack(axis: .horizontal, alignment: .center)
-    private lazy var actorsStackView = makeStack(axis: .horizontal, alignment: .center)
+    private let totalStackView = UIStackView().makeStackView(axis: .vertical, alignment: .leading, spacing: 8)
+    private let directorStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let productionYearStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let openingDateStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let durationStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let ratingStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let nationsStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let genresStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
+    private let actorsStackView = UIStackView().makeStackView(axis: .horizontal, alignment: .center, spacing: 8)
     
     // MARK: UILabel
-    private lazy var directorTitleLabel = makeLabel(text: "감독", textAlignment: .center, bold: true)
-    private lazy var directorsLabel = makeLabel(textAlignment: .left, bold: false)
-    private lazy var productionYearTitleLabel = makeLabel(text: "제작년도", textAlignment: .center, bold: true)
-    private lazy var productionYearLabel = makeLabel(textAlignment: .left, bold: false)
-    private lazy var openingDateTitleLabel = makeLabel(text: "개봉일", textAlignment: .center, bold: true)
-    private lazy var openingDateLabel = makeLabel(textAlignment: .center, bold: false)
-    private lazy var durationTitleLabel = makeLabel(text: "상영시간", textAlignment: .center, bold: true)
-    private lazy var durationLabel = makeLabel(textAlignment: .left, bold: false)
-    private lazy var ratingTitleLabel = makeLabel(text: "관람등급", textAlignment: .center, bold: true)
-    private lazy var ratingLabel = makeLabel( textAlignment: .left, bold: false)
-    private lazy var nationsTitleLabel = makeLabel(text: "제작국가", textAlignment: .center, bold: true)
-    private lazy var nationsLabel = makeLabel(textAlignment: .left, bold: false)
-    private lazy var genresTitleLabel = makeLabel(text: "장르", textAlignment: .center, bold: true)
-    private lazy var genresLabel = makeLabel(textAlignment: .left, bold: false)
-    private lazy var actorsTitleLabel = makeLabel(text: "배우", textAlignment: .center, bold: true)
-    private lazy var actorsLabel = makeLabel(textAlignment: .left, bold: false, numberOfLines: 0)
+    private let directorTitleLabel = UILabel().makeDetailLabel(text: "감독", textAlignment: .center, bold: true)
+    private let directorsLabel = UILabel().makeDetailLabel(textAlignment: .left, bold: false)
+    private let productionYearTitleLabel = UILabel().makeDetailLabel(text: "제작년도", textAlignment: .center, bold: true)
+    private let productionYearLabel = UILabel().makeDetailLabel(textAlignment: .left, bold: false)
+    private let openingDateTitleLabel = UILabel().makeDetailLabel(text: "개봉일", textAlignment: .center, bold: true)
+    private let openingDateLabel = UILabel().makeDetailLabel(textAlignment: .center, bold: false)
+    private let durationTitleLabel = UILabel().makeDetailLabel(text: "상영시간", textAlignment: .center, bold: true)
+    private let durationLabel = UILabel().makeDetailLabel(textAlignment: .left, bold: false)
+    private let ratingTitleLabel = UILabel().makeDetailLabel(text: "관람등급", textAlignment: .center, bold: true)
+    private let ratingLabel = UILabel().makeDetailLabel( textAlignment: .left, bold: false)
+    private let nationsTitleLabel = UILabel().makeDetailLabel(text: "제작국가", textAlignment: .center, bold: true)
+    private let nationsLabel = UILabel().makeDetailLabel(textAlignment: .left, bold: false)
+    private let genresTitleLabel = UILabel().makeDetailLabel(text: "장르", textAlignment: .center, bold: true)
+    private let genresLabel = UILabel().makeDetailLabel(textAlignment: .left, bold: false)
+    private let actorsTitleLabel = UILabel().makeDetailLabel(text: "배우", textAlignment: .center, bold: true)
+    private let actorsLabel = UILabel().makeDetailLabel(textAlignment: .left, bold: false, numberOfLines: 0)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -127,31 +127,6 @@ extension MovieDetailView {
     }
 }
 
-// MARK: Custom
-extension MovieDetailView {
-    private func makeStack(axis: NSLayoutConstraint.Axis, alignment: UIStackView.Alignment) -> UIStackView {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = axis
-        stackView.alignment = alignment
-        stackView.distribution = .fill
-        stackView.spacing = 8
-        return stackView
-    }
-    
-    private func makeLabel(text: String? = nil, textAlignment: NSTextAlignment, bold: Bool, numberOfLines: Int? = nil) -> UILabel {
-        let label = UILabel()
-        label.text = text
-        label.font = bold ? .boldSystemFont(ofSize: 15) : .systemFont(ofSize: 15)
-        label.textColor = .black
-        label.textAlignment = textAlignment
-        if let numberOfLines = numberOfLines {
-            label.numberOfLines = numberOfLines
-        }
-        return label
-    }
-}
-
 // MARK: Layout
 extension MovieDetailView {
     private func addSubviewsAndSetupLayout() {
@@ -187,21 +162,21 @@ extension MovieDetailView {
         actorsStackView.addArrangedSubview(actorsLabel)
         movieImageView.addSubview(indicatorView)
     }
+    
     private func setupLayoutViews() {
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             
-            totalStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 10),
-            totalStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 10),
-            totalStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -10),
-            totalStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -10),
-            totalStackView.widthAnchor.constraint(equalToConstant: 410),
+            totalStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            totalStackView.leadingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.leadingAnchor, constant: 10),
+            totalStackView.trailingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.trailingAnchor, constant: -10),
+            totalStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
             
-            movieImageView.widthAnchor.constraint(equalToConstant: 410),
-            movieImageView.heightAnchor.constraint(equalToConstant: 500),
+            movieImageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -20),
+            movieImageView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, multiplier: 1.5),
             
             indicatorView.centerXAnchor.constraint(equalTo: movieImageView.centerXAnchor),
             indicatorView.centerYAnchor.constraint(equalTo: movieImageView.centerYAnchor),

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
@@ -106,7 +106,7 @@ extension MovieDetailViewController {
     
     private func configureLabels(with movie: Movie) {
         navigationItem.title = movie.movieName
-        directorsLabel.text = "\(movie.directors.map { $0.name }.joined(separator: ", "))"
+        directorsLabel.text = "\(movie.directors.isEmpty ? "-" : movie.directors.map { $0.name }.joined(separator: ", "))"
         productionYearLabel.text = "\(movie.productionYear)"
         openingDateLabel.text = "\(Date().openingDayString(day: movie.openingDate, format: DateFormatter.yyMMddDashed))"
         durationLabel.text = "\(movie.duration)분"

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
@@ -22,7 +22,7 @@ final class MovieDetailViewController: UIViewController {
     }
     
     // MARK: UIActivityIndicatorView
-    private lazy var indicatorView: UIActivityIndicatorView = {
+    private let indicatorView: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView()
         indicator.translatesAutoresizingMaskIntoConstraints = false
         indicator.color = UIColor.gray
@@ -68,7 +68,7 @@ final class MovieDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        addSubviewsAndSetupLayout()
+        addSubviews()
         setupLayoutViews()
         bind()
         callMovieData()
@@ -140,7 +140,7 @@ extension MovieDetailViewController {
 
 // MARK: Layout
 extension MovieDetailViewController {
-    private func addSubviewsAndSetupLayout() {
+    private func addSubviews() {
         movieImageView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class MovieDetailView: UIViewController {
+final class MovieDetailViewController: UIViewController {
     private var viewModel: MovieDetailViewModel
     private var callMovieDetailEvent: Observable<Void> = Observable(())
     private var callMovieImageEvent: Observable<Void> = Observable(())
@@ -73,7 +73,7 @@ final class MovieDetailView: UIViewController {
 }
 
 // MARK: Binding
-extension MovieDetailView {
+extension MovieDetailViewController {
     private func callMovieData() {
         input.callMovieDetailEvent.value = ()
         input.callMovieImageEvent.value = ()
@@ -128,7 +128,7 @@ extension MovieDetailView {
 }
 
 // MARK: Layout
-extension MovieDetailView {
+extension MovieDetailViewController {
     private func addSubviewsAndSetupLayout() {
         movieImageView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
@@ -117,22 +117,11 @@ extension MovieDetailViewController {
     }
     
     private func configureImageView(with movieImage: MovieImage) {
-        guard let imageURLString = movieImage.documents.first?.imageURL,
-              let imageURL = URL(string: imageURLString) else {
-            print("URL error")
-            return
-        }
-        DispatchQueue.global().async { [weak self] in
-            do {
-                let imageData = try Data(contentsOf: imageURL)
-                let image = UIImage(data: imageData)
-                DispatchQueue.main.async {
-                    self?.indicatorView.stopAnimating()
-                    self?.indicatorView.removeFromSuperview()
-                    self?.movieImageView.image = image
-                }
-            } catch {
-                print(error.localizedDescription)
+        UIImage.load(with: movieImage) { [weak self] image in
+            DispatchQueue.main.async {
+                self?.indicatorView.stopAnimating()
+                self?.indicatorView.removeFromSuperview()
+                self?.movieImageView.image = image
             }
         }
     }

--- a/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MovieDetailViewController.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 final class MovieDetailViewController: UIViewController {
-    private var viewModel: MovieDetailViewModel
+    private let viewModel: MovieDetailViewModel
+    private let navigator: Navigator
     private var callMovieDetailEvent: Observable<Void> = Observable(())
     private var callMovieImageEvent: Observable<Void> = Observable(())
     
@@ -9,8 +10,10 @@ final class MovieDetailViewController: UIViewController {
                                                         callMovieImageEvent: callMovieImageEvent)
     private lazy var output = viewModel.transform(input: input)
     
-    init(viewModel: MovieDetailViewModel) {
+    init(viewModel: MovieDetailViewModel,
+         navigator: Navigator) {
         self.viewModel = viewModel
+        self.navigator = navigator
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -74,6 +77,14 @@ final class MovieDetailViewController: UIViewController {
 
 // MARK: Binding
 extension MovieDetailViewController {
+    private func setBackButtonAction() {
+        navigationItem.leftBarButtonItem?.action = #selector(goBack)
+    }
+    
+    @objc private func goBack() {
+        navigator.navigate(to: .movieList, from: self)
+    }
+    
     private func callMovieData() {
         input.callMovieDetailEvent.value = ()
         input.callMovieImageEvent.value = ()

--- a/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
@@ -40,17 +40,13 @@ final class MoviesListViewController: UIViewController {
         setupCollectionView()
         setupRefreshControl()
         setupNavigationBar()
-        bind()
-        callViewDidLoadEvent()
+        bindOutput()
+        input.viewDidLoad.value = ()
     }
 }
 
 extension MoviesListViewController {
-    private func callViewDidLoadEvent() {
-        input.viewDidLoad.value = ()
-    }
-    
-    private func bind() {
+    private func bindOutput() {
         output.movies.bind { [weak self] _ in
             self?.reload()
         }

--- a/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
@@ -89,7 +89,7 @@ extension MoviesListViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedMovie = viewModel.movies.value[indexPath.item]
-        let destination = Navigator.Destination.detailMovie(movieCode: selectedMovie.movieCode)
+        let destination = Navigator.Destination.detailMovie(movieCode: selectedMovie.movieCode, movieName: selectedMovie.movieName)
         navigator.navigate(to: destination, from: self)
     }
     

--- a/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 final class MoviesListViewController: UIViewController {
     
     private let viewModel: MoviesListViewModel
+    private let navigator: NavigatorProtocol
     
     private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -17,8 +18,9 @@ final class MoviesListViewController: UIViewController {
     
     private let refreshControl = UIRefreshControl()
     
-    init(viewModel: MoviesListViewModel, isRefreshing: Bool = false) {
+    init(viewModel: MoviesListViewModel, navigator: NavigatorProtocol, isRefreshing: Bool = false) {
         self.viewModel = viewModel
+        self.navigator = navigator
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -49,11 +51,6 @@ extension MoviesListViewController {
             if !isRefreshing {
                 self?.refreshControl.endRefreshing()
             }
-        }
-        viewModel.movieDetail.bind { [weak self] movieDetail in
-            guard let movieDetail = movieDetail else { return }
-            let movieDetailViewController = MovieDetailView(movie: movieDetail)
-            self?.navigationController?.pushViewController(movieDetailViewController, animated: true)
         }
     }
     
@@ -92,7 +89,8 @@ extension MoviesListViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedMovie = viewModel.movies.value[indexPath.item]
-        viewModel.fetchMovieDetail(movieCode: selectedMovie.movieCode)
+        let destination = Navigator.Destination.detailMovie(movieCode: selectedMovie.movieCode)
+        navigator.navigate(to: destination, from: self)
     }
     
     private func reload() {

--- a/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
+++ b/BoxOffice/Presentation/MoviesList/View/MoviesListViewController.swift
@@ -50,6 +50,11 @@ extension MoviesListViewController {
                 self?.refreshControl.endRefreshing()
             }
         }
+        viewModel.movieDetail.bind { [weak self] movieDetail in
+            guard let movieDetail = movieDetail else { return }
+            let movieDetailViewController = MovieDetailView(movie: movieDetail)
+            self?.navigationController?.pushViewController(movieDetailViewController, animated: true)
+        }
     }
     
     private func setupNavigationBar() {
@@ -87,12 +92,7 @@ extension MoviesListViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedMovie = viewModel.movies.value[indexPath.item]
-        showMovieDetailScreen(for: selectedMovie)
-    }
-    
-    private func showMovieDetailScreen(for movie: MovieBoxOffice) {
-        let movieDetailViewController = MovieDetailView(movie: movie)
-        navigationController?.pushViewController(movieDetailViewController, animated: true)
+        viewModel.fetchMovieDetail(movieCode: selectedMovie.movieCode)
     }
     
     private func reload() {

--- a/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
+++ b/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  MovieDetailViewModel.swift
+//  BoxOffice
+//
+//  Created by 윤진영 on 3/10/24.
+//
+
+import Foundation

--- a/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
+++ b/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
@@ -56,7 +56,6 @@ class MovieDetailViewModel: ViewModel {
             case .success(let movie):
                 DispatchQueue.main.async {
                     self?.movieDetail.value = movie
-                    print("\(movie.movieCode)")
                 }
             case .failure(let error):
                 self?.errorMessage.value = error.localizedDescription
@@ -70,7 +69,6 @@ class MovieDetailViewModel: ViewModel {
             case .success(let movieImage):
                 DispatchQueue.main.async {
                     self?.movieImage.value = movieImage
-                    print("\(movieName)")
                 }
             case .failure(let error):
                 self?.imageErrorMessage.value = error.localizedDescription

--- a/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
+++ b/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
@@ -1,8 +1,52 @@
-//
-//  MovieDetailViewModel.swift
-//  BoxOffice
-//
-//  Created by 윤진영 on 3/10/24.
-//
+import UIKit
 
-import Foundation
+protocol MovieDetailViewModel {
+    var movieDetail: Observable<Movie?> { get }
+    var errorMessage: Observable<String> { get }
+    var movieImage: Observable<MovieImage?> { get }
+    var imageErrorMessage: Observable<String> { get }
+    func fetchMovieDetail(movieCode: String)
+    func fetchMovieImage(movieName: String)
+}
+
+class DefaltMovieDetailViewModel: MovieDetailViewModel {
+    var movieImage: Observable<MovieImage?> = Observable(nil)
+    var imageErrorMessage: Observable<String> = Observable("")
+    var movieDetail: Observable<Movie?> = Observable(nil)
+    var errorMessage: Observable<String> = Observable("")
+    private let detailUseCase: MovieDetailUseCase
+    private let imageUseCase: MovieImageUseCase
+    
+    init(detailUseCase: MovieDetailUseCase, imageUseCase: MovieImageUseCase) {
+        self.detailUseCase = detailUseCase
+        self.imageUseCase = imageUseCase
+    }
+    
+    func fetchMovieDetail(movieCode: String) {
+        detailUseCase.fetch(movieCode: movieCode) { [weak self] result in
+            switch result {
+            case .success(let movie):
+                DispatchQueue.main.async {
+                    self?.movieDetail.value = movie
+                    print("\(movie.movieCode)")
+                }
+            case .failure(let error):
+                self?.errorMessage.value = error.localizedDescription
+            }
+        }
+    }
+    
+    func fetchMovieImage(movieName: String) {
+        imageUseCase.fetchMovieImage(movieName: movieName) { [weak self] result in
+            switch result {
+            case .success(let movieImage):
+                DispatchQueue.main.async {
+                    self?.movieImage.value = movieImage
+                    print("\(movieName)")
+                }
+            case .failure(let error):
+                self?.imageErrorMessage.value = error.localizedDescription
+            }
+        }
+    }
+}

--- a/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
+++ b/BoxOffice/Presentation/MoviesList/ViewModel/MovieDetailViewModel.swift
@@ -1,28 +1,56 @@
 import UIKit
 
-protocol MovieDetailViewModel {
-    var movieDetail: Observable<Movie?> { get }
-    var errorMessage: Observable<String> { get }
-    var movieImage: Observable<MovieImage?> { get }
-    var imageErrorMessage: Observable<String> { get }
-    func fetchMovieDetail(movieCode: String)
-    func fetchMovieImage(movieName: String)
-}
-
-class DefaltMovieDetailViewModel: MovieDetailViewModel {
-    var movieImage: Observable<MovieImage?> = Observable(nil)
-    var imageErrorMessage: Observable<String> = Observable("")
-    var movieDetail: Observable<Movie?> = Observable(nil)
-    var errorMessage: Observable<String> = Observable("")
-    private let detailUseCase: MovieDetailUseCase
-    private let imageUseCase: MovieImageUseCase
-    
-    init(detailUseCase: MovieDetailUseCase, imageUseCase: MovieImageUseCase) {
-        self.detailUseCase = detailUseCase
-        self.imageUseCase = imageUseCase
+class MovieDetailViewModel: ViewModel {
+    struct Input {
+        var callMovieDetailEvent: Observable<Void>
+        var callMovieImageEvent: Observable<Void>
+    }
+    struct Output {
+        var movieDetail: Observable<Movie?>
+        var errorMessage: Observable<String>
+        var movieImage: Observable<MovieImage?>
+        var imageErrorMessage: Observable<String>
     }
     
-    func fetchMovieDetail(movieCode: String) {
+    private let detailUseCase: MovieDetailUseCase
+    private let imageUseCase: MovieImageUseCase
+    private var movieCode: String
+    private var movieName: String
+    private var movieImage: Observable<MovieImage?> = Observable(nil)
+    private var imageErrorMessage: Observable<String> = Observable("")
+    private var movieDetail: Observable<Movie?> = Observable(nil)
+    private var errorMessage: Observable<String> = Observable("")
+    
+    init(detailUseCase: MovieDetailUseCase,
+         imageUseCase: MovieImageUseCase,
+         movieCode: String,
+         movieName: String) {
+        self.detailUseCase = detailUseCase
+        self.imageUseCase = imageUseCase
+        self.movieCode = movieCode
+        self.movieName = movieName
+    }
+    
+    func transform(input: Input) -> Output {
+        input.callMovieDetailEvent.bind { [weak self] _ in
+            guard let movieCode = self?.movieCode else {
+                return
+            }
+            self?.fetchMovieDetail(movieCode: movieCode)
+        }
+        input.callMovieImageEvent.bind { [weak self] _ in
+            guard let movieName = self?.movieName else {
+                return
+            }
+            self?.fetchMovieImage(movieName: movieName)
+        }
+        return .init(movieDetail: movieDetail,
+                     errorMessage: errorMessage,
+                     movieImage: movieImage,
+                     imageErrorMessage: imageErrorMessage)
+    }
+    
+    private func fetchMovieDetail(movieCode: String) {
         detailUseCase.fetch(movieCode: movieCode) { [weak self] result in
             switch result {
             case .success(let movie):
@@ -36,7 +64,7 @@ class DefaltMovieDetailViewModel: MovieDetailViewModel {
         }
     }
     
-    func fetchMovieImage(movieName: String) {
+    private func fetchMovieImage(movieName: String) {
         imageUseCase.fetchMovieImage(movieName: movieName) { [weak self] result in
             switch result {
             case .success(let movieImage):

--- a/BoxOffice/Presentation/MoviesList/ViewModel/MoviesListViewModel.swift
+++ b/BoxOffice/Presentation/MoviesList/ViewModel/MoviesListViewModel.swift
@@ -6,29 +6,24 @@ protocol MoviesListInput {
     func viewDidLoad()
     func refresh()
     func loadCell(_ index: Int)
-    func fetchMovieDetail(movieCode: String)
 }
 
 protocol MoviesListOutput {
     var movies: Observable<[MovieBoxOffice]> { get }
-    var movieDetail: Observable<Movie?> { get }
     var errorMessage: Observable<String> { get }
     var isRefreshing: Observable<Bool> { get }
     var nowCellInformation: Observable<(String, String, String, UIColor, String)> { get }
 }
 
 final class DefaultMoviesListViewModel: MoviesListViewModel {
-    var movieDetail: Observable<Movie?> = Observable(nil)
-    private let detailUseCase: MovieDetailUseCase
     private let useCase: BoxOfficeUseCase
     var movies: Observable<[MovieBoxOffice]> = Observable([])
     var errorMessage: Observable<String> = Observable("")
     var isRefreshing: Observable<Bool> = Observable(false)
     var nowCellInformation: Observable<(String, String, String, UIColor, String)> = Observable(("", "", "", .white, ""))
     
-    init(useCase: BoxOfficeUseCase, movieUseCase: MovieDetailUseCase) {
+    init(useCase: BoxOfficeUseCase) {
         self.useCase = useCase
-        self.detailUseCase = movieUseCase
     }
     
     private func fetchData() {
@@ -102,19 +97,5 @@ final class DefaultMoviesListViewModel: MoviesListViewModel {
         }
         let cellInformation = (movieName, rank, rankChangeText, rankChangeColor, audienceText)
         nowCellInformation.value = cellInformation
-    }
-    
-    func fetchMovieDetail(movieCode: String) {
-        detailUseCase.fetch(movieCode: movieCode) { [weak self] result in
-            switch result {
-            case .success(let movie):
-                DispatchQueue.main.async {
-                    self?.movieDetail.value = movie
-                    print("\(movieCode)")
-                }
-            case .failure(let error):
-                self?.errorMessage.value = error.localizedDescription
-            }
-        }
     }
 }


### PR DESCRIPTION
안녕하세요. 지성 [@yim2627](https://github.com/yim2627)

시디, 유니입니다.

이번 스텝도 잘 부탁드립니다. 🙇🙇‍♀️

**STEP4 요구사항**

- 영화의 상세내용을 확인할 수 있는 화면을 구현합니다.
- 표시할 영화 정보
    - 제목
    - 포스터 이미지
    - 감독
    - 제작년도
    - 개봉일
    - 상영시간
    - 관람등급
    - 제작국가
    - 장르
    - 배우
    - 영화 포스터 이미지는 `[영화제목] + [영화 포스터]`로 이미지 검색하여 제일 첫 이미지를 사용합니다
    - 이미지가 로드되기 전에는 이미지가 로드중임을 알 수 있도록 적절히 처리해주세요
- 내용이 길어지면 위아래로 스크롤 할 수 있도록 구현해주세요

**질문**

1. 이미지뷰의 로딩화면만 인디케이터로 구현하였는데, 라벨 또한 로딩중임을 표현해 주는게 좋을 것 같은데 이미지뷰와 라벨의 데이터가 로딩되기전까지 하나의 인디케이터로 구현하는게 좋을지, 또 다른 방법이 있는지 궁금합니다.
2. 이미지뷰를 불러오는 현재 디테일뷰컨트롤러에 있는`configureImageView` 메서드 로직이 단순히 뷰의 기능뿐 아니라 데이터를 처리하는 기능을 가지고 있는 것처럼 보이는데 뷰모델과 뷰컨트롤러 중에 어디에 위치해야 하는지 고민이 됩니다.

```swift
private func configureImageView(with movieImage: MovieImage) {
        guard let imageURLString = movieImage.documents.first?.imageURL,
              let imageURL = URL(string: imageURLString) else {
            print("URL error")
            return
        }
        DispatchQueue.global().async { [weak self] in
            do {
                let imageData = try Data(contentsOf: imageURL)
                let image = UIImage(data: imageData)
                DispatchQueue.main.async {
                    self?.indicatorView.stopAnimating()
                    self?.indicatorView.removeFromSuperview()
                    self?.movieImageView.image = image
                }
            } catch {
                print(error.localizedDescription)
            }
        }
    }
```

3. 이번 스텝에서 화면 전환이 추가 되면서 ViewModel에 대한 의존성 주입이 ViewController가 책임을 지게 되면 ViewController의 역할과 무관한 코드들이 생기게 되어 `Navigator`라는 의존성 주입과 화면 전환을 담당하는 객체를 만들어 사용 했습니다. 화면 전환이 얼마 없어 이 역할을 하는 객체에 대한 필요성이 많이 느껴지지는 않았지만 의존성 관리 측면에서 이점이 보여 사용을 했는데 더 좋은 방향이 있을지 궁금합니다! 